### PR TITLE
READY : Covering option `dry`.

### DIFF
--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -21796,7 +21796,7 @@ function startMinimalOptionDry( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, error in options map, con* checks`;
+      test.case = `mode : ${mode}, error in execPath, con* checks`;
 
       let track = [];
 
@@ -21992,178 +21992,118 @@ function startOptionDryMultiple( test )
             {
               test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe' ] );
               test.identical( op2.fullExecPath, `node ${programPath} id:${counter + 1}` );
-          }
+            }
             test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
             track = [];
             return null;
-          } )
-
-          return options.ready;
+          })
         });
-
         return null;
-      } )
-
+      })
     })
 
     /* */
 
-    // ready.then( () =>
-    // {
-    //   test.case = `mode : ${mode}, con* checks`;
-    //   let track = [];
-    //   let options =
-    //   {
-    //     execPath : mode === 'fork' ? programPath : 'node ' + programPath,
-    //     mode,
-    //     outputCollecting : 1,
-    //     dry : 1
-    //   }
+    ready.then( () =>
+    {
+      test.case = `mode : ${mode}, error in execPath, con* checks`;
+      let options =
+      {
+        execPath : [ 'err' + programPath + ' id:1', 'err' + programPath + ' id:2' ],
+        mode,
+        outputCollecting : 1,
+        dry : 1
+      }
 
-    //   _.process.start( options )
+      return _.process.start( options )
+      .then( ( op ) =>
+      {
+        test.identical( op.procedure._name, null );
+        test.identical( op.procedure._object, options );
+        test.identical( op.state, 'terminated' );
+        test.identical( op.exitReason, 'normal' );
+        test.identical( op.exitCode, null );
+        test.identical( op.exitSignal, null );
+        test.identical( op.error, null );
+        test.identical( op.process, undefined );
+        test.identical( op.output, '' );
+        test.identical( op.ended, true );
+        test.is( _.streamIs( op.streamOut ) );
+        test.is( _.streamIs( op.streamErr ) );
+        if( mode === 'fork' )
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+        }
+        else
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+        }
 
-    //   options.conStart.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conStart' );
-    //     test.identical( err, undefined );
-    //     test.identical( op, options );
-    //     test.identical( options.process, null );
-    //     return null;
-    //   })
+        op.runs.forEach( ( op2, counter ) =>
+        {
+          op2.conStart.tap( ( err, op ) =>
+          {
+            track.push( 'conStart' );
+            test.identical( err, undefined );
+            test.identical( op, op2 );
+            test.identical( op2.process, null );
+            return null;
+          })
 
-    //   options.conDisconnect.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conDisconnect' );
-    //     test.identical( err, _.dont );
-    //     test.identical( op, undefined );
-    //     test.identical( options.process, null );
-    //     return null;
-    //   })
+          op2.conDisconnect.tap( ( err, op ) =>
+          {
+            track.push( 'conDisconnect' );
+            test.identical( err, _.dont );
+            test.identical( op, undefined );
+            test.identical( op2.process, null );
+            return null;
+          })
 
-    //   options.conTerminate.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conTerminate' );
-    //     test.identical( err, undefined );
-    //     test.identical( op, options );
-    //     test.identical( options.process, null );
-    //     return null;
-    //   })
+          op2.conTerminate.tap( ( err, op ) =>
+          {
+            track.push( 'conTerminate' );
+            test.identical( err, undefined );
+            test.identical( op, op2 );
+            test.identical( op2.process, null );
+            return null;
+          })
 
-    //   options.ready.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'ready' );
-    //     test.identical( options.process, null );
-    //     test.identical( err, undefined );
-    //     test.identical( op, options );
-    //     test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
-    //     return null;
-    //   } )
-
-    //   return options.ready;
-
-    // })
-
-    // /* */
-
-    // ready.then( () =>
-    // {
-    //   test.case = `mode : ${mode}, error in options map`;
-
-    //   let options =
-    //   {
-    //     execPath : 'err' + programPath,
-    //     mode,
-    //     outputCollecting : 1,
-    //     dry : 1
-    //   }
-
-    //   return _.process.start( options )
-    //   .then( ( op ) =>
-    //   {
-    //     test.identical( op.procedure._name, null );
-    //     test.identical( op.procedure._object, null );
-    //     test.identical( op.state, 'terminated' );
-    //     test.identical( op.exitReason, null );
-    //     test.identical( op.exitCode, null );
-    //     test.identical( op.exitSignal, null );
-    //     test.identical( op.error, null );
-    //     test.identical( op.process, null );
-    //     test.identical( op.output, '' );
-    //     test.identical( op.ended, true );
-    //     test.identical( op.streamOut, null );
-    //     test.identical( op.streamErr, null );
-    //     test.identical( op.fullExecPath, 'err' + programPath );
-    //     if( mode === 'fork' )
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-    //     }
-    //     else
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-    //     }
-
-    //     return null;
-    //   } )
-    // })
-
-    // /* */
-
-    // ready.then( () =>
-    // {
-    //   test.case = `mode : ${mode}, error in options map, con* checks`;
-
-    //   let track = [];
-
-    //   let options =
-    //   {
-    //     execPath : 'err' + programPath,
-    //     mode,
-    //     outputCollecting : 1,
-    //     dry : 1
-    //   }
-
-    //   _.process.start( options )
-
-    //   options.conStart.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conStart' );
-    //     test.identical( err, undefined );
-    //     test.identical( op, options );
-    //     test.identical( options.process, null );
-    //     return null;
-    //   })
-
-    //   options.conDisconnect.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conDisconnect' );
-    //     test.identical( err, _.dont );
-    //     test.identical( op, undefined );
-    //     test.identical( options.process, null );
-    //     return null;
-    //   })
-
-    //   options.conTerminate.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conTerminate' );
-    //     test.identical( err, undefined );
-    //     test.identical( op, options );
-    //     test.identical( options.process, null );
-    //     return null;
-    //   })
-
-    //   options.ready.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'ready' );
-    //     test.identical( options.process, null );
-    //     test.identical( err, undefined );
-    //     test.identical( op, options );
-    //     test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
-    //     return null;
-    //   } )
-
-    //   return options.ready;
-
-    // })
+          op2.ready.tap( ( err, op ) =>
+          {
+            track.push( 'ready' );
+            test.identical( op2.process, null );
+            test.identical( err, undefined );
+            test.identical( op, op2 );
+            test.identical( op2.procedure._name, null );
+            test.identical( op2.procedure._object, null );
+            test.identical( op2.state, 'terminated' );
+            test.identical( op2.exitReason, null );
+            test.identical( op2.exitReason, null );
+            test.identical( op2.exitCode, null );
+            test.identical( op2.exitSignal, null );
+            test.identical( op2.error, null );
+            test.identical( op2.process, null );
+            test.identical( op2.output, '' );
+            test.identical( op2.ended, true );
+            test.identical( op2.streamOut, null );
+            test.identical( op2.streamErr, null );
+            if( mode === 'fork' )
+            {
+              test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+            }
+            else
+            {
+              test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+            }
+            test.identical( op2.fullExecPath, `err${programPath} id:${counter + 1}` );
+            test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
+            track = [];
+            return null;
+          })
+        });
+        return null;
+      })
+    })
 
     return ready;
   }

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -18885,32 +18885,40 @@ function startMinimalOptionDry( test )
 
       _.process.start( options )
 
-      options.conStart.then( () =>
+      options.conStart.tap( ( err, op ) =>
       {
         track.push( 'conStart' );
+        test.identical( err, undefined );
+        test.identical( op, options );
         test.identical( options.process, null );
         return null;
       })
 
-      options.conDisconnect.then( () =>
+      options.conDisconnect.tap( ( err, op ) =>
       {
         track.push( 'conDisconnect' );
+        test.identical( err, Symbol.for( 'dont' ) );
+        test.identical( op, undefined );
         test.identical( options.process, null );
         return null;
       })
 
-      options.conTerminate.then( () =>
+      options.conTerminate.tap( ( err, op ) =>
       {
         track.push( 'conTerminate' );
+        test.identical( err, undefined );
+        test.identical( op, options );
         test.identical( options.process, null );
         return null;
       })
 
-      options.ready.then( ()=>
+      options.ready.tap( ( err, op ) =>
       {
         track.push( 'ready' );
         test.identical( options.process, null );
-        test.identical( track, [ 'conStart', 'conTerminate', 'ready' ] );
+        test.identical( err, undefined );
+        test.identical( op, options );
+        test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
         return null;
       } )
 

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -32749,7 +32749,7 @@ var Proto =
 
     startOptionStreamSizeLimit,
     startOptionStreamSizeLimitThrowing,
-    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough */
+    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough | aaa : Done */
     /* qqq for Yevhen : write test routine startOptionDryMultiple | aaa : Done. */
     startMinimalOptionDry,
     startOptionDryMultiple,

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -22214,126 +22214,91 @@ function startSingleOptionDry( test )
       {
         test.is( !_.consequenceIs( returned ) );
         test.is( returned === o );
-        test.identical( o.process, null );
-        test.identical( returned, o );
-        test.identical( o.procedure._name, null );
-        test.identical( o.procedure._object, null );
-        test.identical( o.state, 'terminated' );
-        test.identical( o.exitReason, null );
-        test.identical( o.exitCode, null );
-        test.identical( o.exitSignal, null );
-        test.identical( o.error, null );
-        test.identical( o.process, null );
-        test.identical( o.output, '' );
-        test.identical( o.ended, true );
-        test.identical( o.streamOut, null );
-        test.identical( o.streamErr, null );
-        if( mode === 'fork' )
-        {
-          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-          test.identical( o.fullExecPath, `${programPath} arg1 arg 2 'arg3' arg0` );
-        }
-        else if ( mode === 'shell' )
-        {
-          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-          if( process.platform === 'win32' )
-          test.identical( o.fullExecPath, `node ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-          else
-          test.identical( o.fullExecPath, `node ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-        }
-        else
-        {
-          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-          test.identical( o.fullExecPath, `node ${programPath} arg1 arg 2 'arg3' arg0` );
-        }
-
-        test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
-        return returned;
       }
       else
       {
         test.is( _.consequenceIs( returned ) );
-
         if( deasync )
         test.identical( returned.resourcesCount(), 1 );
         else
         test.identical( returned.resourcesCount(), 0 );
-
-        o.conStart.tap( ( err, op ) =>
-        {
-          track.push( 'conStart' );
-          test.identical( err, undefined );
-          test.identical( op, o );
-          test.identical( o.process, null );
-          return null;
-        })
-  
-        o.conDisconnect.tap( ( err, op ) =>
-        {
-          track.push( 'conDisconnect' );
-          test.identical( err, _.dont );
-          test.identical( op, undefined );
-          test.identical( o.process, null );
-          return null;
-        })
-  
-        o.conTerminate.tap( ( err, op ) =>
-        {
-          track.push( 'conTerminate' );
-          test.identical( err, undefined );
-          test.identical( op, o );
-          test.identical( o.process, null );
-          return null;
-        })
-  
-        o.ready.tap( ( err, op ) =>
-        {
-          var t2 = _.time.now();
-          test.ge( t2 - t1, 1000 )
-          track.push( 'ready' );
-          test.identical( o.process, null );
-          test.identical( err, undefined );
-          test.identical( op, o );
-          test.identical( op.procedure._name, null );
-          test.identical( op.procedure._object, null );
-          test.identical( op.state, 'terminated' );
-          test.identical( op.exitReason, null );
-          test.identical( op.exitCode, null );
-          test.identical( op.exitSignal, null );
-          test.identical( op.error, null );
-          test.identical( op.process, null );
-          test.identical( op.output, '' );
-          test.identical( op.ended, true );
-          test.identical( op.streamOut, null );
-          test.identical( op.streamErr, null );
-          if( mode === 'fork' )
-          {
-            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-            test.identical( op.fullExecPath, `${programPath} arg1 arg 2 'arg3' arg0` );
-          }
-          else if ( mode === 'shell' )
-          {
-            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-            if( process.platform === 'win32' )
-            test.identical( op.fullExecPath, `node ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-            else
-            test.identical( op.fullExecPath, `node ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-          }
-          else
-          {
-            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-            test.identical( op.fullExecPath, `node ${programPath} arg1 arg 2 'arg3' arg0` );
-          }
-  
-          test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
-          if( deasync )
-          test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
-          else
-          test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
-          track = [];
-          return null;
-        })
       }
+
+      o.conStart.tap( ( err, op ) =>
+      {
+        track.push( 'conStart' );
+        test.identical( err, undefined );
+        test.identical( op, o );
+        test.identical( o.process, null );
+        return null;
+      })
+
+      o.conDisconnect.tap( ( err, op ) =>
+      {
+        track.push( 'conDisconnect' );
+        test.identical( err, _.dont );
+        test.identical( op, undefined );
+        test.identical( o.process, null );
+        return null;
+      })
+
+      o.conTerminate.tap( ( err, op ) =>
+      {
+        track.push( 'conTerminate' );
+        test.identical( err, undefined );
+        test.identical( op, o );
+        test.identical( o.process, null );
+        return null;
+      })
+
+      o.ready.tap( ( err, op ) =>
+      {
+        var t2 = _.time.now();
+        test.ge( t2 - t1, 1000 )
+        track.push( 'ready' );
+        test.identical( o.process, null );
+        test.identical( err, undefined );
+        test.identical( op, o );
+        test.identical( op.procedure._name, null );
+        test.identical( op.procedure._object, null );
+        test.identical( op.state, 'terminated' );
+        test.identical( op.exitReason, null );
+        test.identical( op.exitCode, null );
+        test.identical( op.exitSignal, null );
+        test.identical( op.error, null );
+        test.identical( op.process, null );
+        test.identical( op.output, '' );
+        test.identical( op.ended, true );
+        test.identical( op.streamOut, null );
+        test.identical( op.streamErr, null );
+        if( mode === 'fork' )
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+          test.identical( op.fullExecPath, `${programPath} arg1 arg 2 'arg3' arg0` );
+        }
+        else if ( mode === 'shell' )
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+          if( process.platform === 'win32' )
+          test.identical( op.fullExecPath, `node ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+          else
+          test.identical( op.fullExecPath, `node ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+        }
+        else
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+          test.identical( op.fullExecPath, `node ${programPath} arg1 arg 2 'arg3' arg0` );
+        }
+
+        test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
+        if( deasync )
+        test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
+        else
+        test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
+        track = [];
+        return null;
+      })
+
       return null;
     })
 
@@ -22366,116 +22331,86 @@ function startSingleOptionDry( test )
       {
         test.is( !_.consequenceIs( returned ) );
         test.is( returned === o );
-        test.identical( o.process, null );
-        test.identical( returned, o );
-        test.identical( o.procedure._name, null );
-        test.identical( o.procedure._object, null );
-        test.identical( o.state, 'terminated' );
-        test.identical( o.exitReason, null );
-        test.identical( o.exitCode, null );
-        test.identical( o.exitSignal, null );
-        test.identical( o.error, null );
-        test.identical( o.process, null );
-        test.identical( o.output, '' );
-        test.identical( o.ended, true );
-        test.identical( o.streamOut, null );
-        test.identical( o.streamErr, null );
-        if ( mode === 'shell' )
-        {
-          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-          if( process.platform === 'win32' )
-          test.identical( o.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-          else
-          test.identical( o.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-        }
-        else
-        {
-          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-          test.identical( o.fullExecPath, `err ${programPath} arg1 arg 2 'arg3' arg0` );
-        }
-
-        test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
-        return returned;
       }
       else
       {
         test.is( _.consequenceIs( returned ) );
-
         if( deasync )
         test.identical( returned.resourcesCount(), 1 );
         else
         test.identical( returned.resourcesCount(), 0 );
-
-        o.conStart.tap( ( err, op ) =>
-        {
-          track.push( 'conStart' );
-          test.identical( err, undefined );
-          test.identical( op, o );
-          test.identical( o.process, null );
-          return null;
-        })
-  
-        o.conDisconnect.tap( ( err, op ) =>
-        {
-          track.push( 'conDisconnect' );
-          test.identical( err, _.dont );
-          test.identical( op, undefined );
-          test.identical( o.process, null );
-          return null;
-        })
-  
-        o.conTerminate.tap( ( err, op ) =>
-        {
-          track.push( 'conTerminate' );
-          test.identical( err, undefined );
-          test.identical( op, o );
-          test.identical( o.process, null );
-          return null;
-        })
-  
-        o.ready.tap( ( err, op ) =>
-        {
-          var t2 = _.time.now();
-          test.ge( t2 - t1, 1000 )
-          track.push( 'ready' );
-          test.identical( o.process, null );
-          test.identical( err, undefined );
-          test.identical( op, o );
-          test.identical( op.procedure._name, null );
-          test.identical( op.procedure._object, null );
-          test.identical( op.state, 'terminated' );
-          test.identical( op.exitReason, null );
-          test.identical( op.exitCode, null );
-          test.identical( op.exitSignal, null );
-          test.identical( op.error, null );
-          test.identical( op.process, null );
-          test.identical( op.output, '' );
-          test.identical( op.ended, true );
-          test.identical( op.streamOut, null );
-          test.identical( op.streamErr, null );
-          if ( mode === 'shell' )
-          {
-            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-            if( process.platform === 'win32' )
-            test.identical( op.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-            else
-            test.identical( op.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-          }
-          else
-          {
-            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-            test.identical( op.fullExecPath, `err ${programPath} arg1 arg 2 'arg3' arg0` );
-          }
-  
-          test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
-          if( deasync )
-          test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
-          else
-          test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
-          track = [];
-          return null;
-        })
       }
+
+      o.conStart.tap( ( err, op ) =>
+      {
+        track.push( 'conStart' );
+        test.identical( err, undefined );
+        test.identical( op, o );
+        test.identical( o.process, null );
+        return null;
+      })
+
+      o.conDisconnect.tap( ( err, op ) =>
+      {
+        track.push( 'conDisconnect' );
+        test.identical( err, _.dont );
+        test.identical( op, undefined );
+        test.identical( o.process, null );
+        return null;
+      })
+
+      o.conTerminate.tap( ( err, op ) =>
+      {
+        track.push( 'conTerminate' );
+        test.identical( err, undefined );
+        test.identical( op, o );
+        test.identical( o.process, null );
+        return null;
+      })
+
+      o.ready.tap( ( err, op ) =>
+      {
+        var t2 = _.time.now();
+        test.ge( t2 - t1, 1000 )
+        track.push( 'ready' );
+        test.identical( o.process, null );
+        test.identical( err, undefined );
+        test.identical( op, o );
+        test.identical( op.procedure._name, null );
+        test.identical( op.procedure._object, null );
+        test.identical( op.state, 'terminated' );
+        test.identical( op.exitReason, null );
+        test.identical( op.exitCode, null );
+        test.identical( op.exitSignal, null );
+        test.identical( op.error, null );
+        test.identical( op.process, null );
+        test.identical( op.output, '' );
+        test.identical( op.ended, true );
+        test.identical( op.streamOut, null );
+        test.identical( op.streamErr, null );
+        if ( mode === 'shell' )
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+          if( process.platform === 'win32' )
+          test.identical( op.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+          else
+          test.identical( op.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+        }
+        else
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+          test.identical( op.fullExecPath, `err ${programPath} arg1 arg 2 'arg3' arg0` );
+        }
+
+        test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
+        if( deasync )
+        test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
+        else
+        test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
+        track = [];
+        return null;
+      })
+
       return null;
     })
 
@@ -22534,6 +22469,7 @@ function startOptionDryMultiple( test )
     ready.then( () =>
     {
       test.case = `mode : ${mode}, dry : 1, without error, con* checks`;
+
       let options =
       {
         execPath : [ mode === 'fork' ? programPath + ' id:1' : 'node ' + programPath + ' id:1', mode === 'fork' ? programPath + ' id:2' : 'node ' + programPath + ' id:2' ],
@@ -22542,8 +22478,17 @@ function startOptionDryMultiple( test )
         dry : 1
       }
 
-      return _.process.start( options )
-      .then( ( op ) =>
+      let returned = _.process.start( options )
+
+      if( sync )
+      {
+
+      }
+      else
+      {
+
+      }
+      returned.then( ( op ) =>
       {
         test.identical( op.procedure._name, null );
         test.identical( op.procedure._object, options );

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -22166,51 +22166,51 @@ function startSingleOptionDry( test )
   let track = [];
 
   let modes = [ 'fork', 'spawn', 'shell' ];
-  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 0, 0 ) ) );
-  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 0, 1 ) ) );
-  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 0 ) ) );
-  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 1 ) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run({ mode, sync : 0, deasync : 0 }) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run({ mode, sync : 0, deasync : 1 }) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run({ mode, sync : 1, deasync : 0 }) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run({ mode, sync : 1, deasync : 1 }) ) );
   return a.ready;
 
-  function run( mode, sync, deasync )
+  function run( tops )
   {
     let ready = new _.Consequence().take( null );
 
-    if( sync && !deasync && mode === 'fork' )
+    if( tops.sync && !tops.deasync && tops.mode === 'fork' )
     return test.shouldThrowErrorSync( () =>
     {
       _.process.start
       ({
         execPath : programPath + ` arg1 "arg 2" "'arg3'"`,
-        mode,
-        sync,
-        deasync
+        mode : tops.mode,
+        sync : tops.sync,
+        deasync : tops.deasync
       })
     });
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, sync : ${sync}, deasync : ${deasync}, dry : 1, no error`
+      test.case = `mode : ${tops.mode}, sync : ${tops.sync}, deasync : ${tops.deasync}, dry : 1, no error`
       let o =
       {
-        execPath : mode === 'fork' ? programPath + ` arg1 "arg 2" "'arg3'"` : 'node ' + programPath + ` arg1 "arg 2" "'arg3'"`,
-        mode,
-        sync,
-        deasync,
+        execPath : tops.mode === 'fork' ? programPath + ` arg1 "arg 2" "'arg3'"` : 'node ' + programPath + ` arg1 "arg 2" "'arg3'"`,
+        mode : tops.mode,
+        sync : tops.sync,
+        deasync : tops.deasync,
         args : [ 'arg0' ],
         dry : 1,
         outputPiping : 1,
         outputCollecting : 1,
         throwingExitCode : 1,
         applyingExitCode : 1,
-        timeOut : sync || !deasync ? null : 100,
-        ipc : mode === 'shell' ? 0 : 1,
+        timeOut : tops.sync || !tops.deasync ? null : 100,
+        ipc : tops.mode === 'shell' ? 0 : 1,
         when : { delay : 1000 }
       }
       var t1 = _.time.now();
       var returned = _.process.start( o );
 
-      if( sync )
+      if( tops.sync )
       {
         test.is( !_.consequenceIs( returned ) );
         test.is( returned === o );
@@ -22218,7 +22218,7 @@ function startSingleOptionDry( test )
       else
       {
         test.is( _.consequenceIs( returned ) );
-        if( deasync )
+        if( tops.deasync )
         test.identical( returned.resourcesCount(), 1 );
         else
         test.identical( returned.resourcesCount(), 0 );
@@ -22271,12 +22271,12 @@ function startSingleOptionDry( test )
         test.identical( op.ended, true );
         test.identical( op.streamOut, null );
         test.identical( op.streamErr, null );
-        if( mode === 'fork' )
+        if( tops.mode === 'fork' )
         {
           test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
           test.identical( op.fullExecPath, `${programPath} arg1 arg 2 'arg3' arg0` );
         }
-        else if ( mode === 'shell' )
+        else if ( tops.mode === 'shell' )
         {
           test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
           if( process.platform === 'win32' )
@@ -22291,7 +22291,7 @@ function startSingleOptionDry( test )
         }
 
         test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
-        if( deasync )
+        if( tops.deasync )
         test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
         else
         test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
@@ -22307,27 +22307,27 @@ function startSingleOptionDry( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, sync : ${sync}, deasync : ${deasync}, dry : 1, execPath : 'err' + programPath + \` arg1 "arg 2" "'arg3'"\``
+      test.case = `mode : ${tops.mode}, sync : ${tops.sync}, deasync : ${tops.deasync}, dry : 1, execPath : 'err' + programPath + \` arg1 "arg 2" "'arg3'"\``
       let o =
       {
         execPath : 'err ' + programPath + ` arg1 "arg 2" "'arg3'"`,
-        mode,
-        sync,
-        deasync,
+        mode : tops.mode,
+        sync : tops.sync,
+        deasync : tops.deasync,
         args : [ 'arg0' ],
         dry : 1,
         outputPiping : 1,
         outputCollecting : 1,
         throwingExitCode : 1,
         applyingExitCode : 1,
-        timeOut : sync || !deasync ? null : 100,
-        ipc : mode === 'shell' ? 0 : 1,
+        timeOut : tops.sync || !tops.deasync ? null : 100,
+        ipc : tops.mode === 'shell' ? 0 : 1,
         when : { delay : 1000 }
       }
       var t1 = _.time.now();
       var returned = _.process.start( o );
 
-      if( sync )
+      if( tops.sync )
       {
         test.is( !_.consequenceIs( returned ) );
         test.is( returned === o );
@@ -22335,7 +22335,7 @@ function startSingleOptionDry( test )
       else
       {
         test.is( _.consequenceIs( returned ) );
-        if( deasync )
+        if( tops.deasync )
         test.identical( returned.resourcesCount(), 1 );
         else
         test.identical( returned.resourcesCount(), 0 );
@@ -22388,7 +22388,7 @@ function startSingleOptionDry( test )
         test.identical( op.ended, true );
         test.identical( op.streamOut, null );
         test.identical( op.streamErr, null );
-        if ( mode === 'shell' )
+        if ( tops.mode === 'shell' )
         {
           test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
           if( process.platform === 'win32' )
@@ -22403,7 +22403,7 @@ function startSingleOptionDry( test )
         }
 
         test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
-        if( deasync )
+        if( tops.deasync )
         test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
         else
         test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
@@ -22444,242 +22444,233 @@ function startOptionDryMultiple( test )
   let track = [];
 
   let modes = [ 'fork', 'spawn', 'shell' ];
-  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 0, 0 ) ) );
-  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 0, 1 ) ) );
-  // modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 0 ) ) );
-  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 1 ) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run({ mode, sync : 0, deasync : 0 }) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run({ mode, sync : 0, deasync : 1 }) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run({ mode, sync : 1, deasync : 0 }) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run({ mode, sync : 1, deasync : 1 }) ) );
   return a.ready;
 
-  function run( mode, sync, deasync )
+  function run( tops )
   {
     let ready = new _.Consequence().take( null );
 
-    if( sync && !deasync && mode === 'fork' )
+    if( tops.sync && !tops.deasync && tops.mode === 'fork' )
     return test.shouldThrowErrorSync( () =>
     {
       _.process.start
       ({
         execPath : [ programPath + ` arg1 "arg 2" "'arg3'"`, programPath + ` arg1 "arg 2" "'arg3'"` ],
-        mode,
-        sync,
-        deasync
+        mode : tops.mode,
+        sync : tops.sync,
+        deasync : tops.deasync
       })
     });
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, dry : 1, without error, con* checks`;
+      test.case = `mode : ${tops.mode}, sync : ${tops.sync}, deasync :${tops.deasync}, dry : 1, without error, con* checks`;
 
       let options =
       {
-        execPath : [ mode === 'fork' ? programPath + ' id:1' : 'node ' + programPath + ' id:1', mode === 'fork' ? programPath + ' id:2' : 'node ' + programPath + ' id:2' ],
-        mode,
+        execPath : [ tops.mode === 'fork' ? programPath + ' id:1' : 'node ' + programPath + ' id:1', tops.mode === 'fork' ? programPath + ' id:2' : 'node ' + programPath + ' id:2' ],
+        mode : tops.mode,
+        sync : tops.sync,
+        deasync : tops.deasync,
         outputCollecting : 1,
         dry : 1
       }
 
       let returned = _.process.start( options )
 
-      if( sync )
+      test.identical( options.procedure._name, null );
+      test.identical( options.state, 'terminated' );
+      test.identical( options.exitReason, 'normal' );
+      test.identical( options.exitCode, null );
+      test.identical( options.exitSignal, null );
+      test.identical( options.error, null );
+      test.identical( options.process, undefined );
+      test.identical( options.output, '' );
+      test.identical( options.ended, true );
+      test.is( _.streamIs( options.streamOut ) );
+      test.is( _.streamIs( options.streamErr ) );
+      if( tops.mode === 'fork' )
       {
-
+        test.identical( options.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
       }
       else
       {
-
+        test.identical( options.stdio, [ 'pipe', 'pipe', 'pipe' ] );
       }
-      returned.then( ( op ) =>
+
+      options.runs.forEach( ( op2, counter ) =>
       {
-        test.identical( op.procedure._name, null );
-        test.identical( op.procedure._object, options );
-        test.identical( op.state, 'terminated' );
-        test.identical( op.exitReason, 'normal' );
-        test.identical( op.exitCode, null );
-        test.identical( op.exitSignal, null );
-        test.identical( op.error, null );
-        test.identical( op.process, undefined );
-        test.identical( op.output, '' );
-        test.identical( op.ended, true );
-        test.is( _.streamIs( op.streamOut ) );
-        test.is( _.streamIs( op.streamErr ) );
-        if( mode === 'fork' )
+        op2.conStart.tap( ( err, op ) =>
         {
-          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-        }
-        else
+          track.push( 'conStart' );
+          test.identical( err, undefined );
+          test.identical( op, op2 );
+          test.identical( op2.process, null );
+          return null;
+        })
+
+        op2.conDisconnect.tap( ( err, op ) =>
         {
-          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-        }
+          track.push( 'conDisconnect' );
+          test.identical( err, _.dont );
+          test.identical( op, undefined );
+          test.identical( op2.process, null );
+          return null;
+        })
 
-        op.runs.forEach( ( op2, counter ) =>
+        op2.conTerminate.tap( ( err, op ) =>
         {
-          op2.conStart.tap( ( err, op ) =>
-          {
-            track.push( 'conStart' );
-            test.identical( err, undefined );
-            test.identical( op, op2 );
-            test.identical( op2.process, null );
-            return null;
-          })
+          track.push( 'conTerminate' );
+          test.identical( err, undefined );
+          test.identical( op, op2 );
+          test.identical( op2.process, null );
+          return null;
+        })
 
-          op2.conDisconnect.tap( ( err, op ) =>
+        op2.ready.tap( ( err, op ) =>
+        {
+          track.push( 'ready' );
+          test.identical( op2.process, null );
+          test.identical( err, undefined );
+          test.identical( op, op2 );
+          test.identical( op2.procedure._name, null );
+          test.identical( op2.procedure._object, null );
+          test.identical( op2.state, 'terminated' );
+          test.identical( op2.exitReason, null );
+          test.identical( op2.exitReason, null );
+          test.identical( op2.exitCode, null );
+          test.identical( op2.exitSignal, null );
+          test.identical( op2.error, null );
+          test.identical( op2.process, null );
+          test.identical( op2.output, '' );
+          test.identical( op2.ended, true );
+          test.identical( op2.streamOut, null );
+          test.identical( op2.streamErr, null );
+          if( tops.mode === 'fork' )
           {
-            track.push( 'conDisconnect' );
-            test.identical( err, _.dont );
-            test.identical( op, undefined );
-            test.identical( op2.process, null );
-            return null;
-          })
-
-          op2.conTerminate.tap( ( err, op ) =>
+            test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+            test.identical( op2.fullExecPath, programPath + ` id:${counter + 1}` );
+          }
+          else
           {
-            track.push( 'conTerminate' );
-            test.identical( err, undefined );
-            test.identical( op, op2 );
-            test.identical( op2.process, null );
-            return null;
-          })
-
-          op2.ready.tap( ( err, op ) =>
-          {
-            track.push( 'ready' );
-            test.identical( op2.process, null );
-            test.identical( err, undefined );
-            test.identical( op, op2 );
-            test.identical( op2.procedure._name, null );
-            test.identical( op2.procedure._object, null );
-            test.identical( op2.state, 'terminated' );
-            test.identical( op2.exitReason, null );
-            test.identical( op2.exitReason, null );
-            test.identical( op2.exitCode, null );
-            test.identical( op2.exitSignal, null );
-            test.identical( op2.error, null );
-            test.identical( op2.process, null );
-            test.identical( op2.output, '' );
-            test.identical( op2.ended, true );
-            test.identical( op2.streamOut, null );
-            test.identical( op2.streamErr, null );
-            if( mode === 'fork' )
-            {
-              test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-              test.identical( op2.fullExecPath, programPath + ` id:${counter + 1}` );
-            }
-            else
-            {
-              test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-              test.identical( op2.fullExecPath, `node ${programPath} id:${counter + 1}` );
-            }
-            test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
-            track = [];
-            return null;
-          })
-        });
-        return null;
-      })
+            test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+            test.identical( op2.fullExecPath, `node ${programPath} id:${counter + 1}` );
+          }
+          test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
+          track = [];
+          return null;
+        })
+      });
+      return null;
     })
 
     /* */
 
-    // ready.then( () =>
-    // {
-    //   test.case = `mode : ${mode}, dry : 1, error in execPath, con* checks`;
-    //   let options =
-    //   {
-    //     execPath : [ 'err' + programPath + ' id:1', 'err' + programPath + ' id:2' ],
-    //     mode,
-    //     outputCollecting : 1,
-    //     dry : 1
-    //   }
+    ready.then( () =>
+    {
+      test.case = `mode : ${tops.mode}, sync : ${tops.sync}, deasync :${tops.deasync}, dry : 1, without error, con* checks`;
 
-    //   return _.process.start( options )
-    //   .then( ( op ) =>
-    //   {
-    //     test.identical( op.procedure._name, null );
-    //     test.identical( op.procedure._object, options );
-    //     test.identical( op.state, 'terminated' );
-    //     test.identical( op.exitReason, 'normal' );
-    //     test.identical( op.exitCode, null );
-    //     test.identical( op.exitSignal, null );
-    //     test.identical( op.error, null );
-    //     test.identical( op.process, undefined );
-    //     test.identical( op.output, '' );
-    //     test.identical( op.ended, true );
-    //     test.is( _.streamIs( op.streamOut ) );
-    //     test.is( _.streamIs( op.streamErr ) );
-    //     if( mode === 'fork' )
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-    //     }
-    //     else
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-    //     }
+      let options =
+      {
+        execPath : [ 'err ' + programPath + ' id:1', 'err ' + programPath + ' id:2' ],
+        mode : tops.mode,
+        sync : tops.sync,
+        deasync : tops.deasync,
+        outputCollecting : 1,
+        dry : 1
+      }
 
-    //     op.runs.forEach( ( op2, counter ) =>
-    //     {
-    //       op2.conStart.tap( ( err, op ) =>
-    //       {
-    //         track.push( 'conStart' );
-    //         test.identical( err, undefined );
-    //         test.identical( op, op2 );
-    //         test.identical( op2.process, null );
-    //         return null;
-    //       })
+      let returned = _.process.start( options )
 
-    //       op2.conDisconnect.tap( ( err, op ) =>
-    //       {
-    //         track.push( 'conDisconnect' );
-    //         test.identical( err, _.dont );
-    //         test.identical( op, undefined );
-    //         test.identical( op2.process, null );
-    //         return null;
-    //       })
+      test.identical( options.procedure._name, null );
+      test.identical( options.state, 'terminated' );
+      test.identical( options.exitReason, 'normal' );
+      test.identical( options.exitCode, null );
+      test.identical( options.exitSignal, null );
+      test.identical( options.error, null );
+      test.identical( options.process, undefined );
+      test.identical( options.output, '' );
+      test.identical( options.ended, true );
+      test.is( _.streamIs( options.streamOut ) );
+      test.is( _.streamIs( options.streamErr ) );
+      if( tops.mode === 'fork' )
+      {
+        test.identical( options.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+      }
+      else
+      {
+        test.identical( options.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+      }
 
-    //       op2.conTerminate.tap( ( err, op ) =>
-    //       {
-    //         track.push( 'conTerminate' );
-    //         test.identical( err, undefined );
-    //         test.identical( op, op2 );
-    //         test.identical( op2.process, null );
-    //         return null;
-    //       })
+      options.runs.forEach( ( op2, counter ) =>
+      {
+        op2.conStart.tap( ( err, op ) =>
+        {
+          track.push( 'conStart' );
+          test.identical( err, undefined );
+          test.identical( op, op2 );
+          test.identical( op2.process, null );
+          return null;
+        })
 
-    //       op2.ready.tap( ( err, op ) =>
-    //       {
-    //         track.push( 'ready' );
-    //         test.identical( op2.process, null );
-    //         test.identical( err, undefined );
-    //         test.identical( op, op2 );
-    //         test.identical( op2.procedure._name, null );
-    //         test.identical( op2.procedure._object, null );
-    //         test.identical( op2.state, 'terminated' );
-    //         test.identical( op2.exitReason, null );
-    //         test.identical( op2.exitReason, null );
-    //         test.identical( op2.exitCode, null );
-    //         test.identical( op2.exitSignal, null );
-    //         test.identical( op2.error, null );
-    //         test.identical( op2.process, null );
-    //         test.identical( op2.output, '' );
-    //         test.identical( op2.ended, true );
-    //         test.identical( op2.streamOut, null );
-    //         test.identical( op2.streamErr, null );
-    //         if( mode === 'fork' )
-    //         {
-    //           test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-    //         }
-    //         else
-    //         {
-    //           test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-    //         }
-    //         test.identical( op2.fullExecPath, `err${programPath} id:${counter + 1}` );
-    //         test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
-    //         track = [];
-    //         return null;
-    //       })
-    //     });
-    //     return null;
-    //   })
-    // })
+        op2.conDisconnect.tap( ( err, op ) =>
+        {
+          track.push( 'conDisconnect' );
+          test.identical( err, _.dont );
+          test.identical( op, undefined );
+          test.identical( op2.process, null );
+          return null;
+        })
+
+        op2.conTerminate.tap( ( err, op ) =>
+        {
+          track.push( 'conTerminate' );
+          test.identical( err, undefined );
+          test.identical( op, op2 );
+          test.identical( op2.process, null );
+          return null;
+        })
+
+        op2.ready.tap( ( err, op ) =>
+        {
+          track.push( 'ready' );
+          test.identical( op2.process, null );
+          test.identical( err, undefined );
+          test.identical( op, op2 );
+          test.identical( op2.procedure._name, null );
+          test.identical( op2.procedure._object, null );
+          test.identical( op2.state, 'terminated' );
+          test.identical( op2.exitReason, null );
+          test.identical( op2.exitReason, null );
+          test.identical( op2.exitCode, null );
+          test.identical( op2.exitSignal, null );
+          test.identical( op2.error, null );
+          test.identical( op2.process, null );
+          test.identical( op2.output, '' );
+          test.identical( op2.ended, true );
+          test.identical( op2.streamOut, null );
+          test.identical( op2.streamErr, null );
+          if( tops.mode === 'fork' )
+          {
+            test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+            test.identical( op2.fullExecPath, 'err ' + programPath + ` id:${counter + 1}` );
+          }
+          else
+          {
+            test.identical( op2.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+            test.identical( op2.fullExecPath, `err ${programPath} id:${counter + 1}` );
+          }
+          test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
+          track = [];
+          return null;
+        })
+      });
+      return null;
+    })
 
     return ready;
   }

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -21601,7 +21601,7 @@ function startOptionDry( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let programPath = a.program( testApp );
+  let programPath = a.path.nativize( a.program( testApp ) );
 
   let modes = [ 'fork', 'spawn', 'shell' ];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
@@ -21888,7 +21888,7 @@ function startOptionDryMultiple( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let programPath = a.program( testApp );
+  let programPath = a.path.nativize( a.program( testApp ) );
   let track = [];
 
   let modes = [ 'fork', 'spawn', 'shell' ];

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -21615,7 +21615,7 @@ function startSingleOptionDry( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, trivial, no error `
+      test.case = `mode : ${mode}, dry : 1, no error`
       let o =
       {
         execPath : mode === 'fork' ? programPath + ` arg1 "arg 2" "'arg3'"` : 'node ' + programPath + ` arg1 "arg 2" "'arg3'"`,
@@ -21716,7 +21716,7 @@ function startSingleOptionDry( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, execPath : 'err' + programPath + args`
+      test.case = `mode : ${mode}, dry : 1, execPath : 'err' + programPath + \` arg1 "arg 2" "'arg3'"\``
       let o =
       {
         execPath : 'err' + programPath + ` arg1 "arg 2" "'arg3'"`,
@@ -21852,7 +21852,7 @@ function startOptionDryMultiple( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, without error, con* checks`;
+      test.case = `mode : ${mode}, dry : 1, without error, con* checks`;
       let options =
       {
         execPath : [ mode === 'fork' ? programPath + ' id:1' : 'node ' + programPath + ' id:1', mode === 'fork' ? programPath + ' id:2' : 'node ' + programPath + ' id:2' ],
@@ -21956,7 +21956,7 @@ function startOptionDryMultiple( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, error in execPath, con* checks`;
+      test.case = `mode : ${mode}, dry : 1, error in execPath, con* checks`;
       let options =
       {
         execPath : [ 'err' + programPath + ' id:1', 'err' + programPath + ' id:2' ],

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -20572,11 +20572,10 @@ function startOptionDryMultiple( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, outputCollecting : 1`;
-
+      test.case = `mode : ${mode}, basic`;
       let options =
       {
-        execPath : mode === 'fork' ? programPath : 'node ' + programPath,
+        execPath : [ mode === 'fork' ? programPath + ' id:1' : 'node ' + programPath + ' id:1', mode === 'fork' ? programPath + ' id:2' : 'node ' + programPath + ' id:2' ],
         mode,
         outputCollecting : 1,
         dry : 1
@@ -20585,32 +20584,223 @@ function startOptionDryMultiple( test )
       return _.process.start( options )
       .then( ( op ) =>
       {
+        console.log( `mode : ${mode}; OPPPPPP: `, op );
         test.identical( op.procedure._name, null );
-        test.identical( op.procedure._object, null );
+        // test.identical( op.procedure._object, null );
         test.identical( op.state, 'terminated' );
-        test.identical( op.exitReason, null );
+        // test.identical( op.exitReason, null );
+        test.identical( op.exitReason, 'normal' );
         test.identical( op.exitCode, null );
         test.identical( op.exitSignal, null );
         test.identical( op.error, null );
-        test.identical( op.process, null );
+        // test.identical( op.process, null );
         test.identical( op.output, '' );
         test.identical( op.ended, true );
-        test.identical( op.streamOut, null );
-        test.identical( op.streamErr, null );
+        // test.identical( op.streamOut, null );
+        // test.identical( op.streamErr, null );
         if( mode === 'fork' )
         {
           test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-          test.identical( op.fullExecPath, programPath );
+          // test.identical( op.fullExecPath, programPath );
         }
         else
         {
           test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-          test.identical( op.fullExecPath, `node ${programPath}` );
+          // test.identical( op.fullExecPath, `node ${programPath}` );
         }
+
+        op.runs.forEach( ( op2, counter ) =>
+        {
+          // console.log( `mode : ${mode}, OPOPPOPOPO#${counter} : `, op2 )
+          test.identical( op2.procedure._name, null );
+          test.identical( op2.procedure._object, null );
+          test.identical( op2.state, 'terminated' );
+          test.identical( op2.exitReason, null );
+          test.identical( op2.exitReason, null );
+          test.identical( op2.exitCode, null );
+          test.identical( op2.exitSignal, null );
+          test.identical( op2.error, null );
+          test.identical( op2.process, null );
+          test.identical( op2.output, '' );
+          test.identical( op2.ended, true );
+          test.identical( op2.streamOut, null );
+          test.identical( op2.streamErr, null );
+          if( mode === 'fork' )
+          {
+            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+            // test.identical( op.fullExecPath, programPath + `id:${counter}` );
+          }
+          else
+          {
+            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+            test.identical( op.execPath, `node ${programPath} id:${counter}` );
+            test.identical( op.execPath, `node ${programPath} id:${counter}` );
+          }
+        });
 
         return null;
       } )
+
     })
+
+    /* */
+
+    // ready.then( () =>
+    // {
+    //   test.case = `mode : ${mode}, con* checks`;
+    //   let track = [];
+    //   let options =
+    //   {
+    //     execPath : mode === 'fork' ? programPath : 'node ' + programPath,
+    //     mode,
+    //     outputCollecting : 1,
+    //     dry : 1
+    //   }
+
+    //   _.process.start( options )
+
+    //   options.conStart.tap( ( err, op ) =>
+    //   {
+    //     track.push( 'conStart' );
+    //     test.identical( err, undefined );
+    //     test.identical( op, options );
+    //     test.identical( options.process, null );
+    //     return null;
+    //   })
+
+    //   options.conDisconnect.tap( ( err, op ) =>
+    //   {
+    //     track.push( 'conDisconnect' );
+    //     test.identical( err, _.dont );
+    //     test.identical( op, undefined );
+    //     test.identical( options.process, null );
+    //     return null;
+    //   })
+
+    //   options.conTerminate.tap( ( err, op ) =>
+    //   {
+    //     track.push( 'conTerminate' );
+    //     test.identical( err, undefined );
+    //     test.identical( op, options );
+    //     test.identical( options.process, null );
+    //     return null;
+    //   })
+
+    //   options.ready.tap( ( err, op ) =>
+    //   {
+    //     track.push( 'ready' );
+    //     test.identical( options.process, null );
+    //     test.identical( err, undefined );
+    //     test.identical( op, options );
+    //     test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
+    //     return null;
+    //   } )
+
+    //   return options.ready;
+
+    // })
+
+    // /* */
+
+    // ready.then( () =>
+    // {
+    //   test.case = `mode : ${mode}, error in options map`;
+
+    //   let options =
+    //   {
+    //     execPath : 'err' + programPath,
+    //     mode,
+    //     outputCollecting : 1,
+    //     dry : 1
+    //   }
+
+    //   return _.process.start( options )
+    //   .then( ( op ) =>
+    //   {
+    //     test.identical( op.procedure._name, null );
+    //     test.identical( op.procedure._object, null );
+    //     test.identical( op.state, 'terminated' );
+    //     test.identical( op.exitReason, null );
+    //     test.identical( op.exitCode, null );
+    //     test.identical( op.exitSignal, null );
+    //     test.identical( op.error, null );
+    //     test.identical( op.process, null );
+    //     test.identical( op.output, '' );
+    //     test.identical( op.ended, true );
+    //     test.identical( op.streamOut, null );
+    //     test.identical( op.streamErr, null );
+    //     test.identical( op.fullExecPath, 'err' + programPath );
+    //     if( mode === 'fork' )
+    //     {
+    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+    //     }
+    //     else
+    //     {
+    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+    //     }
+
+    //     return null;
+    //   } )
+    // })
+
+    // /* */
+
+    // ready.then( () =>
+    // {
+    //   test.case = `mode : ${mode}, error in options map, con* checks`;
+
+    //   let track = [];
+
+    //   let options =
+    //   {
+    //     execPath : 'err' + programPath,
+    //     mode,
+    //     outputCollecting : 1,
+    //     dry : 1
+    //   }
+
+    //   _.process.start( options )
+
+    //   options.conStart.tap( ( err, op ) =>
+    //   {
+    //     track.push( 'conStart' );
+    //     test.identical( err, undefined );
+    //     test.identical( op, options );
+    //     test.identical( options.process, null );
+    //     return null;
+    //   })
+
+    //   options.conDisconnect.tap( ( err, op ) =>
+    //   {
+    //     track.push( 'conDisconnect' );
+    //     test.identical( err, _.dont );
+    //     test.identical( op, undefined );
+    //     test.identical( options.process, null );
+    //     return null;
+    //   })
+
+    //   options.conTerminate.tap( ( err, op ) =>
+    //   {
+    //     track.push( 'conTerminate' );
+    //     test.identical( err, undefined );
+    //     test.identical( op, options );
+    //     test.identical( options.process, null );
+    //     return null;
+    //   })
+
+    //   options.ready.tap( ( err, op ) =>
+    //   {
+    //     track.push( 'ready' );
+    //     test.identical( options.process, null );
+    //     test.identical( err, undefined );
+    //     test.identical( op, options );
+    //     test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
+    //     return null;
+    //   } )
+
+    //   return options.ready;
+
+    // })
 
     return ready;
   }
@@ -20618,25 +20808,6 @@ function startOptionDryMultiple( test )
   /* - */
 
   function testApp()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wProcess' );
-    _.include( 'wFiles' );
-
-    let options =
-    {
-      execPath : 'node ' + programPath,
-      dry : 1,
-      outputCollecting : 1,
-      // throwingExitCode : 0,
-      // outputPiping : 0,
-      // verbosity
-    }
-
-    return _.process.start( options );
-  }
-
-  function testApp2()
   {
     console.log( 'Not printed' );
   }

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -21713,53 +21713,11 @@ function startMinimalOptionDry( test )
   {
     let ready = new _.Consequence().take( null );
 
-    // ready.then( () =>
-    // {
-    //   test.case = `mode : ${mode}, basic`;
-
-    //   let options =
-    //   {
-    //     execPath : mode === 'fork' ? programPath : 'node ' + programPath,
-    //     mode,
-    //     outputCollecting : 1,
-    //     dry : 1
-    //   }
-
-    //   return _.process.start( options )
-    //   .then( ( op ) =>
-    //   {
-    //     test.identical( op.procedure._name, null );
-    //     test.identical( op.procedure._object, null );
-    //     test.identical( op.state, 'terminated' );
-    //     test.identical( op.exitReason, null );
-    //     test.identical( op.exitCode, null );
-    //     test.identical( op.exitSignal, null );
-    //     test.identical( op.error, null );
-    //     test.identical( op.process, null );
-    //     test.identical( op.output, '' );
-    //     test.identical( op.ended, true );
-    //     test.identical( op.streamOut, null );
-    //     test.identical( op.streamErr, null );
-    //     if( mode === 'fork' )
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-    //       test.identical( op.fullExecPath, programPath );
-    //     }
-    //     else
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-    //       test.identical( op.fullExecPath, `node ${programPath}` );
-    //     }
-
-    //     return null;
-    //   } )
-    // })
-
     /* */
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, con* checks`;
+      test.case = `mode : ${mode}, without error, con* checks`;
       let track = [];
       let options =
       {
@@ -21804,31 +21762,6 @@ function startMinimalOptionDry( test )
         test.identical( options.process, null );
         test.identical( err, undefined );
         test.identical( op, options );
-        test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
-        return null;
-      } )
-
-      return options.ready;
-
-    })
-
-    /* */
-
-    ready.then( () =>
-    {
-      test.case = `mode : ${mode}, error in options map`;
-
-      let options =
-      {
-        execPath : 'err' + programPath,
-        mode,
-        outputCollecting : 1,
-        dry : 1
-      }
-
-      return _.process.start( options )
-      .then( ( op ) =>
-      {
         test.identical( op.procedure._name, null );
         test.identical( op.procedure._object, null );
         test.identical( op.state, 'terminated' );
@@ -21841,18 +21774,22 @@ function startMinimalOptionDry( test )
         test.identical( op.ended, true );
         test.identical( op.streamOut, null );
         test.identical( op.streamErr, null );
-        test.identical( op.fullExecPath, 'err' + programPath );
         if( mode === 'fork' )
         {
           test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+          test.identical( op.fullExecPath, programPath );
         }
         else
         {
           test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+          test.identical( op.fullExecPath, `node ${programPath}` );
         }
-
+        test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
         return null;
       } )
+
+      return options.ready;
+
     })
 
     /* */
@@ -21871,7 +21808,7 @@ function startMinimalOptionDry( test )
         dry : 1
       }
 
-      _.process.start( options )
+      _.process.start( options );
 
       options.conStart.tap( ( err, op ) =>
       {
@@ -21906,6 +21843,27 @@ function startMinimalOptionDry( test )
         test.identical( options.process, null );
         test.identical( err, undefined );
         test.identical( op, options );
+        test.identical( op.procedure._name, null );
+        test.identical( op.procedure._object, null );
+        test.identical( op.state, 'terminated' );
+        test.identical( op.exitReason, null );
+        test.identical( op.exitCode, null );
+        test.identical( op.exitSignal, null );
+        test.identical( op.error, null );
+        test.identical( op.process, null );
+        test.identical( op.output, '' );
+        test.identical( op.ended, true );
+        test.identical( op.streamOut, null );
+        test.identical( op.streamErr, null );
+        test.identical( op.fullExecPath, 'err' + programPath );
+        if( mode === 'fork' )
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+        }
+        else
+        {
+          test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+        }
         test.identical( track, [ 'conStart', 'conDisconnect' ,'conTerminate', 'ready' ] );
         return null;
       } )

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -1,4 +1,3 @@
-/* eslint-disable */
 ( function _ProcessBasic_test_s( )
 {
 

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -29371,7 +29371,7 @@ var Proto =
 
     // other options
 
-    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough */
+    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough. */
     /* qqq for Yevhen : write test routine startOptionDryMultiple */
     startOptionCurrentPath,
     startOptionCurrentPaths,

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -22157,6 +22157,7 @@ function startOptionStreamSizeLimitThrowing( test )
 }
 
 //
+
 function startSingleOptionDry( test )
 {
   let context = this;
@@ -22339,104 +22340,144 @@ function startSingleOptionDry( test )
 
     /* */
 
-    // ready.then( () =>
-    // {
-    //   test.case = `mode : ${mode}, dry : 1, execPath : 'err' + programPath + \` arg1 "arg 2" "'arg3'"\``
-    //   let o =
-    //   {
-    //     execPath : 'err' + programPath + ` arg1 "arg 2" "'arg3'"`,
-    //     mode,
-    //     args : [ 'arg0' ],
-    //     sync : 0,
-    //     dry : 1,
-    //     deasync : 0,
-    //     outputPiping : 1,
-    //     outputCollecting : 1,
-    //     throwingExitCode : 1,
-    //     applyingExitCode : 1,
-    //     timeOut : 100,
-    //     ipc : mode === 'shell' ? 0 : 1,
-    //     when : { delay : 1000 }
-    //   }
-    //   var t1 = _.time.now();
-    //   var returned = _.process.start( o );
-    //   test.is( _.consequenceIs( returned ) );
+    ready.then( () =>
+    {
+      test.case = `mode : ${mode}, sync : ${sync}, deasync : ${deasync}, dry : 1, execPath : 'err' + programPath + \` arg1 "arg 2" "'arg3'"\``
+      let o =
+      {
+        execPath : 'err ' + programPath + ` arg1 "arg 2" "'arg3'"`,
+        mode,
+        sync,
+        deasync,
+        args : [ 'arg0' ],
+        dry : 1,
+        outputPiping : 1,
+        outputCollecting : 1,
+        throwingExitCode : 1,
+        applyingExitCode : 1,
+        timeOut : sync || !deasync ? null : 100,
+        ipc : mode === 'shell' ? 0 : 1,
+        when : { delay : 1000 }
+      }
+      var t1 = _.time.now();
+      var returned = _.process.start( o );
 
-    //   o.conStart.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conStart' );
-    //     test.identical( err, undefined );
-    //     test.identical( op, o );
-    //     test.identical( o.process, null );
-    //     return null;
-    //   })
+      if( sync )
+      {
+        test.is( !_.consequenceIs( returned ) );
+        test.is( returned === o );
+        test.identical( o.process, null );
+        test.identical( returned, o );
+        test.identical( o.procedure._name, null );
+        test.identical( o.procedure._object, null );
+        test.identical( o.state, 'terminated' );
+        test.identical( o.exitReason, null );
+        test.identical( o.exitCode, null );
+        test.identical( o.exitSignal, null );
+        test.identical( o.error, null );
+        test.identical( o.process, null );
+        test.identical( o.output, '' );
+        test.identical( o.ended, true );
+        test.identical( o.streamOut, null );
+        test.identical( o.streamErr, null );
+        if ( mode === 'shell' )
+        {
+          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+          if( process.platform === 'win32' )
+          test.identical( o.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+          else
+          test.identical( o.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+        }
+        else
+        {
+          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+          test.identical( o.fullExecPath, `err ${programPath} arg1 arg 2 'arg3' arg0` );
+        }
 
-    //   o.conDisconnect.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conDisconnect' );
-    //     test.identical( err, _.dont );
-    //     test.identical( op, undefined );
-    //     test.identical( o.process, null );
-    //     return null;
-    //   })
+        test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
+        return returned;
+      }
+      else
+      {
+        test.is( _.consequenceIs( returned ) );
 
-    //   o.conTerminate.tap( ( err, op ) =>
-    //   {
-    //     track.push( 'conTerminate' );
-    //     test.identical( err, undefined );
-    //     test.identical( op, o );
-    //     test.identical( o.process, null );
-    //     return null;
-    //   })
+        if( deasync )
+        test.identical( returned.resourcesCount(), 1 );
+        else
+        test.identical( returned.resourcesCount(), 0 );
 
-    //   o.ready.tap( ( err, op ) =>
-    //   {
-    //     var t2 = _.time.now();
-    //     test.ge( t2 - t1, 1000 )
-    //     track.push( 'ready' );
-    //     test.identical( o.process, null );
-    //     test.identical( err, undefined );
-    //     test.identical( op, o );
-    //     test.identical( op.procedure._name, null );
-    //     test.identical( op.procedure._object, null );
-    //     test.identical( op.state, 'terminated' );
-    //     test.identical( op.exitReason, null );
-    //     test.identical( op.exitCode, null );
-    //     test.identical( op.exitSignal, null );
-    //     test.identical( op.error, null );
-    //     test.identical( op.process, null );
-    //     test.identical( op.output, '' );
-    //     test.identical( op.ended, true );
-    //     test.identical( op.streamOut, null );
-    //     test.identical( op.streamErr, null );
-    //     if( mode === 'fork' )
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-    //       test.identical( op.fullExecPath, `err${programPath} arg1 arg 2 'arg3' arg0` );
-    //     }
-    //     else if ( mode === 'shell' )
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-    //       if( process.platform === 'win32' )
-    //       test.identical( op.fullExecPath, `err${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-    //       else
-    //       test.identical( op.fullExecPath, `err${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
-    //     }
-    //     else
-    //     {
-    //       test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
-    //       test.identical( op.fullExecPath, `err${programPath} arg1 arg 2 'arg3' arg0` );
-    //     }
-
-    //     test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
-    //     test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
-    //     track = [];
-
-    //     return op;
-    //   })
-
-    //   return returned;
-    // })
+        o.conStart.tap( ( err, op ) =>
+        {
+          track.push( 'conStart' );
+          test.identical( err, undefined );
+          test.identical( op, o );
+          test.identical( o.process, null );
+          return null;
+        })
+  
+        o.conDisconnect.tap( ( err, op ) =>
+        {
+          track.push( 'conDisconnect' );
+          test.identical( err, _.dont );
+          test.identical( op, undefined );
+          test.identical( o.process, null );
+          return null;
+        })
+  
+        o.conTerminate.tap( ( err, op ) =>
+        {
+          track.push( 'conTerminate' );
+          test.identical( err, undefined );
+          test.identical( op, o );
+          test.identical( o.process, null );
+          return null;
+        })
+  
+        o.ready.tap( ( err, op ) =>
+        {
+          var t2 = _.time.now();
+          test.ge( t2 - t1, 1000 )
+          track.push( 'ready' );
+          test.identical( o.process, null );
+          test.identical( err, undefined );
+          test.identical( op, o );
+          test.identical( op.procedure._name, null );
+          test.identical( op.procedure._object, null );
+          test.identical( op.state, 'terminated' );
+          test.identical( op.exitReason, null );
+          test.identical( op.exitCode, null );
+          test.identical( op.exitSignal, null );
+          test.identical( op.error, null );
+          test.identical( op.process, null );
+          test.identical( op.output, '' );
+          test.identical( op.ended, true );
+          test.identical( op.streamOut, null );
+          test.identical( op.streamErr, null );
+          if ( mode === 'shell' )
+          {
+            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+            if( process.platform === 'win32' )
+            test.identical( op.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+            else
+            test.identical( op.fullExecPath, `err ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+          }
+          else
+          {
+            test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+            test.identical( op.fullExecPath, `err ${programPath} arg1 arg 2 'arg3' arg0` );
+          }
+  
+          test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
+          if( deasync )
+          test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
+          else
+          test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
+          track = [];
+          return null;
+        })
+      }
+      return null;
+    })
 
     return ready;
   }

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -32749,7 +32749,7 @@ var Proto =
 
     startOptionStreamSizeLimit,
     startOptionStreamSizeLimitThrowing,
-    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough | aaa : Done. */
+    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough */
     /* qqq for Yevhen : write test routine startOptionDryMultiple | aaa : Done. */
     startMinimalOptionDry,
     startOptionDryMultiple,

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -32749,8 +32749,8 @@ var Proto =
 
     startOptionStreamSizeLimit,
     startOptionStreamSizeLimitThrowing,
-    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough */
-    /* qqq for Yevhen : write test routine startOptionDryMultiple */
+    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough | aaa : Done. */
+    /* qqq for Yevhen : write test routine startOptionDryMultiple | aaa : Done. */
     startMinimalOptionDry,
     startOptionDryMultiple,
     startOptionCurrentPath,

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -21882,12 +21882,27 @@ function startOptionDryMultiple( test )
   let track = [];
 
   let modes = [ 'fork', 'spawn', 'shell' ];
-  modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 0, 0 ) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 0, 1 ) ) );
+  // modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 0 ) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 1 ) ) );
   return a.ready;
 
-  function run( mode )
+  function run( mode, sync, deasync )
   {
     let ready = new _.Consequence().take( null );
+
+    if( sync && !deasync && mode === 'fork' )
+    return test.shouldThrowErrorSync( () =>
+    {
+      _.process.start
+      ({
+        execPath : [ programPath + ` arg1 "arg 2" "'arg3'"`, programPath + ` arg1 "arg 2" "'arg3'"` ],
+        mode,
+        sync,
+        deasync
+      })
+    });
 
     ready.then( () =>
     {

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -18994,6 +18994,25 @@ function startOptionDryMultiple( test )
 
   function testApp()
   {
+    let _ = require( toolsPath );
+    _.include( 'wProcess' );
+    _.include( 'wFiles' );
+
+    let options =
+    {
+      execPath : 'node ' + programPath,
+      dry : 1,
+      outputCollecting : 1,
+      // throwingExitCode : 0,
+      // outputPiping : 0,
+      // verbosity
+    }
+
+    return _.process.start( options );
+  }
+
+  function testApp2()
+  {
     console.log( 'Not printed' );
   }
 }

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -22164,10 +22164,10 @@ function startSingleOptionDry( test )
   let programPath = a.program( testApp );
   let track = [];
 
-  let modes = [ /*'fork',*/ 'spawn', /*'shell' */];
+  let modes = [ 'fork', 'spawn', 'shell' ];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode, 0, 0 ) ) );
   modes.forEach( ( mode ) => a.ready.then( () => run( mode, 0, 1 ) ) );
-  // modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 0 ) ) );
+  modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 0 ) ) );
   modes.forEach( ( mode ) => a.ready.then( () => run( mode, 1, 1 ) ) );
   return a.ready;
 
@@ -22208,17 +22208,50 @@ function startSingleOptionDry( test )
       }
       var t1 = _.time.now();
       var returned = _.process.start( o );
-      test.is( _.consequenceIs( returned ) );
 
       if( sync )
       {
         test.is( !_.consequenceIs( returned ) );
         test.is( returned === o );
+        test.identical( o.process, null );
+        test.identical( returned, o );
+        test.identical( o.procedure._name, null );
+        test.identical( o.procedure._object, null );
+        test.identical( o.state, 'terminated' );
+        test.identical( o.exitReason, null );
+        test.identical( o.exitCode, null );
+        test.identical( o.exitSignal, null );
+        test.identical( o.error, null );
+        test.identical( o.process, null );
+        test.identical( o.output, '' );
+        test.identical( o.ended, true );
+        test.identical( o.streamOut, null );
+        test.identical( o.streamErr, null );
+        if( mode === 'fork' )
+        {
+          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+          test.identical( o.fullExecPath, `${programPath} arg1 arg 2 'arg3' arg0` );
+        }
+        else if ( mode === 'shell' )
+        {
+          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe' ] );
+          if( process.platform === 'win32' )
+          test.identical( o.fullExecPath, `node ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+          else
+          test.identical( o.fullExecPath, `node ${programPath} arg1 "arg 2" "'arg3'" "arg0"` );
+        }
+        else
+        {
+          test.identical( o.stdio, [ 'pipe', 'pipe', 'pipe', 'ipc' ] );
+          test.identical( o.fullExecPath, `node ${programPath} arg1 arg 2 'arg3' arg0` );
+        }
+
+        test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
         return returned;
       }
       else
       {
-        // test.is( _.consequenceIs( returned ) );
+        test.is( _.consequenceIs( returned ) );
 
         if( deasync )
         test.identical( returned.resourcesCount(), 1 );
@@ -22292,16 +22325,15 @@ function startSingleOptionDry( test )
           }
   
           test.is( !a.fileProvider.fileExists( a.path.join( a.routinePath, 'file' ) ) )
-          // console.log( `${mode} sync : ${sync} deasync : ${deasync}, TRACK : ${track}` )
           if( deasync )
           test.identical( track, [ 'conStart', 'conDisconnect', 'conTerminate', 'ready' ] );
+          else
+          test.identical( track, [ 'conStart', 'conTerminate', 'conDisconnect', 'ready' ] );
           track = [];
-  
+          return null;
         })
-        return null;
       }
-
-      return returned;
+      return null;
     })
 
 

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -20633,8 +20633,8 @@ function startOptionDryMultiple( test )
           else
           {
             test.identical( op.stdio, [ 'pipe', 'pipe', 'pipe' ] );
-            test.identical( op.execPath, `node ${programPath} id:${counter}` );
-            test.identical( op.execPath, `node ${programPath} id:${counter}` );
+            // test.identical( op.execPath, `node ${programPath} id:${counter}` );
+            // test.identical( op.execPath, `node ${programPath} id:${counter}` );
           }
         });
 

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -21601,7 +21601,7 @@ function startOptionDry( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let programPath = a.path.nativize( a.program( testApp ) );
+  let programPath = a.program( testApp );
 
   let modes = [ 'fork', 'spawn', 'shell' ];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );

--- a/proto/wtools/abase/l4.test/ProcessBasic.test.s
+++ b/proto/wtools/abase/l4.test/ProcessBasic.test.s
@@ -20344,7 +20344,7 @@ function startMinimalOptionDry( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, outputCollecting : 1`;
+      test.case = `mode : ${mode}, basic`;
 
       let options =
       {
@@ -20388,7 +20388,7 @@ function startMinimalOptionDry( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${mode}, outputCollecting : 1, con* checks`;
+      test.case = `mode : ${mode}, con* checks`;
       let track = [];
       let options =
       {
@@ -20412,7 +20412,7 @@ function startMinimalOptionDry( test )
       options.conDisconnect.tap( ( err, op ) =>
       {
         track.push( 'conDisconnect' );
-        test.identical( err, Symbol.for( 'dont' ) );
+        test.identical( err, _.dont );
         test.identical( op, undefined );
         test.identical( options.process, null );
         return null;
@@ -20440,6 +20440,8 @@ function startMinimalOptionDry( test )
       return options.ready;
 
     })
+
+    /* Add error cases */
 
     return ready;
   }

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -1922,9 +1922,9 @@ function start_body( o )
       processPipeCounter += 1;
       if( err )
       return;
-      if( o2.process.stdout )
+      if( o2.process?.stdout )
       streamPipe( o.streamOut, o2.process.stdout );
-      if( o2.process.stderr )
+      if( o2.process?.stderr )
       streamPipe( o.streamErr, o2.process.stderr );
     });
 

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -600,6 +600,7 @@ function startMinimal_body( o )
 
     let o2 = optionsForSpawn();
 
+    /* if( interpreterArgs ) */
     o.fullExecPath = _.strConcat( _.arrayAppendArray( [ execPath ], o.args ) );
     inputMirror();
 

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -1734,8 +1734,8 @@ function start_body( o )
       conTerminate.push( o2.conTerminate );
       readies.push( o2.ready );
 
-      if( o.streamOut || o.streamErr )
       if( !o.dry )
+      if( o.streamOut || o.streamErr )
       processPipe( o2 );
 
       if( !o.concurrent )

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -542,6 +542,7 @@ function startMinimal_body( o )
 
       if( o.sync && !o.deasync )
       {
+        /* When dry : 1, o.process = null */
         if( o.process.error )
         handleError( o.process.error );
         else

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -1922,9 +1922,9 @@ function start_body( o )
       processPipeCounter += 1;
       if( err )
       return;
-      if( o2.process?.stdout )
+      if( o2.process.stdout )
       streamPipe( o.streamOut, o2.process.stdout );
-      if( o2.process?.stderr )
+      if( o2.process.stderr )
       streamPipe( o.streamErr, o2.process.stderr );
     });
 

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -615,7 +615,6 @@ function startMinimal_body( o )
 
     let o2 = optionsForSpawn();
 
-    /* if( interpreterArgs ) */
     o.fullExecPath = _.strConcat( _.arrayAppendArray( [ execPath ], o.args ) );
     inputMirror();
 


### PR DESCRIPTION
1. Extended test routine `startOptionDry`.
    startOptionDry, /* qqq for Yevhen : make sure option dry is covered good enough. */
    /* qqq for Yevhen : write test routine startOptionDryMultiple */
2. Wrote test routine `startSingleOptionDry`.
3. Wrore test routine `startOptionDryMultiple`.
4. Added check for option `dry` in routine `run2`.
5. Fixed according to the review.
6. Extended test coverage.
7. Bug in routine `run2`, left a comment.
if( o.sync && !o.deasync )
      {
        /* When dry : 1, o.process = null */
        if( o.process.error )
        handleError( o.process.error );
        else
        handleClose( o.process.status, o.process.signal );
      }
