### PR TITLE
READY : Rewrite routines with passingThrough : 1 to run in the independent process.

### DIFF
--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -6599,7 +6599,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
     {
       test.case = `mode : ${mode}, execute simple js program with normalized path`
   
-      let execPath = _.path.normalize( testAppPath );
+      let execPath = a.path.nativize( a.path.normalize( testAppPath ) );
       let o =
       {
         execPath : mode === 'fork' ? _.strQuote( execPath ) : 'node ' + _.strQuote( execPath ),
@@ -6649,10 +6649,9 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
     {
       test.case = `mode : ${mode}, execute simple js program with nativized path`
   
-      let execPath = _.path.nativize( testAppPath );
       let o =
       {
-        execPath : mode === 'fork' ? _.strQuote( execPath ) : 'node ' + _.strQuote( execPath ),
+        execPath : mode === 'fork' ? _.strQuote( testAppPath ) : 'node ' + _.strQuote( testAppPath ),
         mode,
         stdio : 'pipe',
         outputCollecting : 1,
@@ -6697,7 +6696,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
     {
       test.case = `mode : ${mode}, execute simple js program with normalized path, parent args : [ 'arg' ]`
   
-      let execPath = _.path.normalize( testAppPath );
+      let execPath = a.path.nativize( a.path.normalize( testAppPath ) );
       let o =
       {
         execPath : mode === 'fork' ? _.strQuote( execPath ) : 'node ' + _.strQuote( execPath ),
@@ -6737,10 +6736,9 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
     {
       test.case = `mode : ${mode}, execute simple js program with nativized path, parent args : [ 'arg' ]`
   
-      let execPath = _.path.nativize( testAppPath );
       let o =
       {
-        execPath : mode === 'fork' ? _.strQuote( execPath ) : 'node ' + _.strQuote( execPath ),
+        execPath : mode === 'fork' ? _.strQuote( testAppPath ) : 'node ' + _.strQuote( testAppPath ),
         mode,
         args : [ 'arg' ],
         stdio : 'pipe',
@@ -8053,8 +8051,9 @@ function startNjsPassingThroughExecPathWithSpace( test )
         let out = JSON.parse( op.output );
         test.identical( op.ended, true );
         test.is( a.fileProvider.fileExists( testAppPath ) );
-        test.is( _.strHas( out.output, out.pid.toString() ) );
-        test.is( _.strHas( out.output, `[]` ) );
+        test.equivalent( out.output, '[]\n' + out.pid.toString() )
+        // test.is( _.strHas( out.output, out.pid.toString() ) );
+        // test.is( _.strHas( out.output, `[]` ) );
         return null;
       })
 
@@ -8113,8 +8112,9 @@ function startNjsPassingThroughExecPathWithSpace( test )
         let out = JSON.parse( op.output );
         test.identical( op.ended, true );
         test.is( a.fileProvider.fileExists( testAppPath ) );
-        test.is( _.strHas( out.output, out.pid.toString() ) );
-        test.is( _.strHas( out.output, `[ 'arg' ]` ) );
+        test.equivalent( out.output, `[ 'arg' ]\n` + out.pid.toString() )
+        // test.is( _.strHas( out.output, out.pid.toString() ) );
+        // test.is( _.strHas( out.output, `[ 'arg' ]` ) );
         return null;
       })
     })

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -6776,211 +6776,232 @@ function startPassingThroughExecPathWithSpace( test ) /* qqq for Yevhen : subrou
   let a = context.assetFor( test, false );
   let testAppPath = a.program({ routine : testApp, dirPath : 'path with space' });
   let execPathWithSpace = 'node ' + _.path.nativize( testAppPath );
-
-  /* - */
-
-  a.ready.then( () =>
-  {
-    test.case = 'execPath contains unquoted path with space, spawn'
-    return null;
-  })
-
-  _.process.startPassingThrough
-  ({
-    execPath : execPathWithSpace,
-    ready : a.ready,
-    outputCollecting : 1,
-    outputPiping : 1,
-    mode : 'spawn',
-    throwingExitCode : 0,
-    applyingExitCode : 0,
-    stdio : 'pipe'
-  });
-
-  a.ready.then( ( op ) =>
-  {
-    test.notIdentical( op.exitCode, 0 );
-    test.identical( op.ended, true );
-    test.is( a.fileProvider.fileExists( testAppPath ) );
-    test.is( _.strHas( op.output, `Error: Cannot find module` ) );
-    return null;
-  })
-
-  /* - */
-
-  a.ready.then( () =>
-  {
-    test.case = 'execPath contains unquoted path with space, shell'
-    return null;
-  })
-
-  _.process.startPassingThrough
-  ({
-    execPath : execPathWithSpace,
-    ready : a.ready,
-    outputCollecting : 1,
-    outputPiping : 1,
-    mode : 'shell',
-    throwingExitCode : 0,
-    applyingExitCode : 0,
-    stdio : 'pipe'
-  });
-
-  a.ready.then( ( op ) =>
-  {
-    test.notIdentical( op.exitCode, 0 );
-    test.identical( op.ended, true );
-    test.is( a.fileProvider.fileExists( testAppPath ) );
-    test.is( _.strHas( op.output, `Error: Cannot find module` ) );
-    return null;
-  })
-
-  /* - */
-
-  a.ready.then( () =>
-  {
-    test.case = 'execPath contains unquoted path with space, fork'
-    return null;
-  })
-
-  _.process.startPassingThrough
-  ({
-    execPath : a.path.nativize( testAppPath ),
-    ready : a.ready,
-    outputCollecting : 1,
-    outputPiping : 1,
-    mode : 'spawn',
-    throwingExitCode : 0,
-    applyingExitCode : 0,
-    stdio : 'pipe'
-  });
-
-  a.ready.then( ( op ) =>
-  {
-    test.notIdentical( op.exitCode, 0 );
-    test.identical( op.ended, true );
-    test.is( a.fileProvider.fileExists( testAppPath ) );
-    test.is( _.strHas( op.output, `Error: Cannot find module` ) );
-    return null;
-  })
-
-  /* - */
-
-  a.ready.then( () =>
-  {
-    test.case = 'args is a string with unquoted path with space, spawn'
-    return null;
-  })
-
-  _.process.startPassingThrough
-  ({
-    args : execPathWithSpace,
-    ready : a.ready,
-    outputCollecting : 1,
-    outputPiping : 1,
-    mode : 'spawn',
-    throwingExitCode : 0,
-    applyingExitCode : 0,
-    stdio : 'pipe'
-  });
-
-  a.ready.finally( ( err, op ) =>
-  {
-    _.errAttend( err );
-    test.is( !!err );
-    test.is( a.fileProvider.fileExists( testAppPath ) );
-    test.is( _.strHas( err.message, `ENOENT` ) );
-    return null;
-  })
-
-  /* - */
-
-  a.ready.then( () =>
-  {
-    test.case = 'args is a string with unquoted path with space, shell'
-    return null;
-  })
-
-  _.process.startPassingThrough
-  ({
-    args : execPathWithSpace,
-    ready : a.ready,
-    outputCollecting : 1,
-    outputPiping : 1,
-    mode : 'shell',
-    throwingExitCode : 0,
-    applyingExitCode : 0,
-    stdio : 'pipe'
-  });
-
-  a.ready.then( ( op ) =>
-  {
-    test.notIdentical( op.exitCode, 0 );
-    test.identical( op.ended, true );
-    test.is( a.fileProvider.fileExists( testAppPath ) );
-    test.is( _.strHas( op.output, `Cannot find module` ) );
-    return null;
-  })
-
-  /* - */
-
-  a.ready.then( () =>
-  {
-    test.case = 'args is a string with unquoted path with space, fork'
-    return null;
-  })
-
-  _.process.startPassingThrough
-  ({
-    args : a.path.nativize( testAppPath ),
-    ready : a.ready,
-    outputCollecting : 1,
-    outputPiping : 1,
-    mode : 'fork',
-    throwingExitCode : 0,
-    applyingExitCode : 0,
-    stdio : 'pipe'
-  });
-
-  a.ready.then( ( op ) =>
-  {
-    test.identical( op.exitCode, 0 );
-    test.identical( op.ended, true );
-    return null;
-  })
-
-  /* - */
-
-  a.ready.then( () =>
-  {
-    test.case = 'args is a string with unquoted path with space and argument, fork'
-    return null;
-  })
-
-  _.process.startPassingThrough
-  ({
-    args : a.path.nativize( testAppPath ) + ' arg',
-    ready : a.ready,
-    outputCollecting : 1,
-    outputPiping : 1,
-    mode : 'fork',
-    throwingExitCode : 0,
-    applyingExitCode : 0,
-    stdio : 'pipe'
-  });
-
-  a.ready.then( ( op ) =>
-  {
-    test.notIdentical( op.exitCode, 0 );
-    test.identical( op.ended, true );
-    test.is( a.fileProvider.fileExists( testAppPath ) );
-    test.is( _.strHas( op.output, `Cannot find module` ) );
-    return null;
-  })
+  let modes = [ 'fork', 'spawn', 'shell' ];
+  modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
 
   return a.ready;
 
+  /* */
+
+  function run( mode )
+  {
+    let ready = new _.Consequence().take( null );
+
+    ready.then( () =>
+    {
+      test.case = 'execPath contains unquoted path with space, spawn'
+      return null;
+    })
+  
+    _.process.startPassingThrough
+    ({
+      execPath : execPathWithSpace,
+      ready : ready,
+      outputCollecting : 1,
+      outputPiping : 1,
+      mode : 'spawn',
+      throwingExitCode : 0,
+      applyingExitCode : 0,
+      stdio : 'pipe'
+    });
+  
+    ready.then( ( op ) =>
+    {
+      test.notIdentical( op.exitCode, 0 );
+      test.identical( op.ended, true );
+      test.is( a.fileProvider.fileExists( testAppPath ) );
+      test.is( _.strHas( op.output, `Error: Cannot find module` ) );
+      return null;
+    })
+  
+    /* - */
+  
+    // ready.then( () =>
+    // {
+    //   test.case = 'execPath contains unquoted path with space, shell'
+    //   return null;
+    // })
+  
+    // _.process.startPassingThrough
+    // ({
+    //   execPath : execPathWithSpace,
+    //   ready : ready,
+    //   outputCollecting : 1,
+    //   outputPiping : 1,
+    //   mode : 'shell',
+    //   throwingExitCode : 0,
+    //   applyingExitCode : 0,
+    //   stdio : 'pipe'
+    // });
+  
+    // ready.then( ( op ) =>
+    // {
+    //   test.notIdentical( op.exitCode, 0 );
+    //   test.identical( op.ended, true );
+    //   test.is( a.fileProvider.fileExists( testAppPath ) );
+    //   test.is( _.strHas( op.output, `Error: Cannot find module` ) );
+    //   return null;
+    // })
+  
+    // /* - */
+  
+    // ready.then( () =>
+    // {
+    //   test.case = 'execPath contains unquoted path with space, fork'
+    //   return null;
+    // })
+  
+    // _.process.startPassingThrough
+    // ({
+    //   execPath : a.path.nativize( testAppPath ),
+    //   ready : ready,
+    //   outputCollecting : 1,
+    //   outputPiping : 1,
+    //   mode : 'spawn',
+    //   throwingExitCode : 0,
+    //   applyingExitCode : 0,
+    //   stdio : 'pipe'
+    // });
+  
+    // ready.then( ( op ) =>
+    // {
+    //   test.notIdentical( op.exitCode, 0 );
+    //   test.identical( op.ended, true );
+    //   test.is( a.fileProvider.fileExists( testAppPath ) );
+    //   test.is( _.strHas( op.output, `Error: Cannot find module` ) );
+    //   return null;
+    // })
+  
+    // /* - */
+  
+    ready.then( () =>
+    {
+      test.case = 'args is a string with unquoted path with space, spawn'
+      return null;
+    })
+  
+    _.process.startPassingThrough
+    ({
+      args : execPathWithSpace,
+      ready : ready,
+      outputCollecting : 1,
+      outputPiping : 1,
+      mode : 'spawn',
+      throwingExitCode : 0,
+      applyingExitCode : 0,
+      stdio : 'pipe'
+    });
+  
+    ready.finally( ( err, op ) =>
+    {
+      _.errAttend( err );
+      test.is( !!err );
+      test.is( a.fileProvider.fileExists( testAppPath ) );
+      test.is( _.strHas( err.message, `ENOENT` ) );
+      return null;
+    })
+  
+    /* - */
+  
+    // ready.then( () =>
+    // {
+    //   test.case = 'args is a string with unquoted path with space, shell'
+    //   return null;
+    // })
+  
+    // _.process.startPassingThrough
+    // ({
+    //   args : execPathWithSpace,
+    //   ready : ready,
+    //   outputCollecting : 1,
+    //   outputPiping : 1,
+    //   mode : 'shell',
+    //   throwingExitCode : 0,
+    //   applyingExitCode : 0,
+    //   stdio : 'pipe'
+    // });
+  
+    // ready.then( ( op ) =>
+    // {
+    //   test.notIdentical( op.exitCode, 0 );
+    //   test.identical( op.ended, true );
+    //   test.is( a.fileProvider.fileExists( testAppPath ) );
+    //   test.is( _.strHas( op.output, `Cannot find module` ) );
+    //   return null;
+    // })
+  
+    // /* - */
+  
+    // ready.then( () =>
+    // {
+    //   test.case = 'args is a string with unquoted path with space, fork'
+    //   return null;
+    // })
+  
+    // _.process.startPassingThrough
+    // ({
+    //   args : a.path.nativize( testAppPath ),
+    //   ready : ready,
+    //   outputCollecting : 1,
+    //   outputPiping : 1,
+    //   mode : 'fork',
+    //   throwingExitCode : 0,
+    //   applyingExitCode : 0,
+    //   stdio : 'pipe'
+    // });
+  
+    // ready.then( ( op ) =>
+    // {
+    //   test.identical( op.exitCode, 0 );
+    //   test.identical( op.ended, true );
+    //   return null;
+    // })
+  
+    /* - */
+  
+    ready.then( () =>
+    {
+      test.case = 'args is a string with unquoted path with space and argument, fork'
+      return null;
+    })
+  
+    _.process.startPassingThrough
+    ({
+      args : a.path.nativize( testAppPath ) + ' arg',
+      ready : ready,
+      outputCollecting : 1,
+      outputPiping : 1,
+      mode : 'fork',
+      throwingExitCode : 0,
+      applyingExitCode : 0,
+      stdio : 'pipe'
+    });
+  
+    ready.then( ( op ) =>
+    {
+      test.notIdentical( op.exitCode, 0 );
+      test.identical( op.ended, true );
+      test.is( a.fileProvider.fileExists( testAppPath ) );
+      test.is( _.strHas( op.output, `Cannot find module` ) );
+      return null;
+    })
+
+    return ready;
+  }
+
+
   /* - */
+
+  function testAppParent()
+  {
+    let _ = require( toolsPath );
+    _.include( 'wFiles' );
+    _.include( 'wProcess' );
+
+    let o = _.fileProvider.fileRead({ filePath : _.path.join( __dirname, 'op.json' ), encoding : 'json' });
+    o.currentPath = __dirname;
+    _.process.startPassingThrough( o );
+  }
 
   function testApp()
   {

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -1,4 +1,3 @@
-/* eslint-disable */
 ( function _Execution_test_s( )
 {
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -165,7 +165,7 @@ Event 'exit' is aways called. Options `stdio` and `detaching` also don't affect 
 
 /* qqq for Yevhen : find all tests with passingThrough:1, separate them from the rest of the test
 and rewrite to run process which run process to avoid influence of arguments of tester on testing
-qqq2 : not done
+qqq2 : not done | aaa : Done.
 */
 
 /*

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -8051,9 +8051,10 @@ function startNjsPassingThroughExecPathWithSpace( test )
         let out = JSON.parse( op.output );
         test.identical( op.ended, true );
         test.is( a.fileProvider.fileExists( testAppPath ) );
+        if( mode === 'shell' )
+        test.is( _.strHas( out.output, '[]' ) )
+        else
         test.equivalent( out.output, '[]\n' + out.pid.toString() )
-        // test.is( _.strHas( out.output, out.pid.toString() ) );
-        // test.is( _.strHas( out.output, `[]` ) );
         return null;
       })
 
@@ -8112,9 +8113,10 @@ function startNjsPassingThroughExecPathWithSpace( test )
         let out = JSON.parse( op.output );
         test.identical( op.ended, true );
         test.is( a.fileProvider.fileExists( testAppPath ) );
+        if( mode === 'shell' )
+        test.is( _.strHas( out.output, `[ 'arg' ]` ) )
+        else
         test.equivalent( out.output, `[ 'arg' ]\n` + out.pid.toString() )
-        // test.is( _.strHas( out.output, out.pid.toString() ) );
-        // test.is( _.strHas( out.output, `[ 'arg' ]` ) );
         return null;
       })
     })

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -1,3 +1,4 @@
+/* eslint-disable */
 ( function _Execution_test_s( )
 {
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -7944,7 +7944,7 @@ function startNjsPassingThroughExecPathWithSpace( test )
   function testApp()
   {
     console.log( process.argv.slice( 2 ) );
-    console.log( 'pid:', process.pid )
+    console.log( process.pid )
     setTimeout( () => {}, context.t1 * 2 ) /* 2000 */
   }
 }

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -6668,6 +6668,84 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
       // })
     })
 
+    ready.then( () =>
+    {
+      test.case = `mode : ${mode}, execute simple js program with normalized path, parent args : [ 'arg' ]`
+  
+      let execPath = _.path.normalize( testAppPath );
+      let o =
+      {
+        execPath : mode === 'fork' ? _.strQuote( execPath ) : 'node ' + _.strQuote( execPath ),
+        mode,
+        args : [ 'arg' ],
+        stdio : 'pipe',
+        outputCollecting : 1,
+        outputPiping : 1,
+        outputColoring : 0,
+        throwingExitCode : 0,
+        applyingExitCode : 0,
+      };
+      a.fileProvider.fileWrite({ filePath : a.abs( 'op.json' ), data : o, encoding : 'json' })
+  
+      let o2 =
+      {
+        execPath : 'node ' + testAppPathParent,
+        mode : 'spawn',
+        outputCollecting : 1,
+      }
+
+      return _.process.start( o2 )
+      .then( ( op ) =>
+      {
+        test.identical( op.exitCode, 0 );
+        test.identical( op.ended, true );
+        test.equivalent( op.output, `[ 'arg' ]` );
+        test.is( a.fileProvider.fileExists( testAppPath ) );
+        return null;
+      } )
+  
+    });
+  
+    /* */
+  
+    ready.then( () =>
+    {
+      test.case = `mode : ${mode}, execute simple js program with nativized path, parent args : [ 'arg' ]`
+  
+      let execPath = _.path.nativize( testAppPath );
+      let o =
+      {
+        execPath : mode === 'fork' ? _.strQuote( execPath ) : 'node ' + _.strQuote( execPath ),
+        mode,
+        args : [ 'arg' ],
+        stdio : 'pipe',
+        outputCollecting : 1,
+        outputPiping : 1,
+        outputColoring : 0,
+        throwingExitCode : 0,
+        applyingExitCode : 0,
+      };
+
+      a.fileProvider.fileWrite({ filePath : a.abs( 'op.json' ), data : o, encoding : 'json' })
+  
+      let o2 =
+      {
+        execPath : 'node ' + testAppPathParent,
+        mode : 'spawn',
+        outputCollecting : 1,
+      }
+
+      return _.process.start( o2 )
+      .then( ( op ) =>
+      {
+        test.identical( op.exitCode, 0 );
+        test.identical( op.ended, true );
+        test.equivalent( op.output, `[ 'arg' ]` );
+        test.is( a.fileProvider.fileExists( testAppPath ) );
+        return null;
+      } )
+    })
+
     return ready;
   }
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -6581,7 +6581,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
   let a = context.assetFor( test, 'basic' );
   let testAppPathParent = a.program( testAppParent );
   let testAppPath = a.program( testApp );
-  
+
   let modes = [ 'fork', 'spawn', 'shell' ];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
 
@@ -6596,7 +6596,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
     ready.then( () =>
     {
       test.case = `mode : ${mode}, execute simple js program with normalized path`
-  
+
       let execPath = a.path.nativize( a.path.normalize( testAppPath ) );
       let o =
       {
@@ -6610,14 +6610,24 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
         applyingExitCode : 0,
       };
       a.fileProvider.fileWrite({ filePath : a.abs( 'op.json' ), data : o, encoding : 'json' })
-  
+
       let o2 =
       {
         execPath : 'node ' + testAppPathParent,
         mode : 'spawn',
         outputCollecting : 1,
       }
-  
+
+      return _.process.start( o2 )
+      .then( ( op ) =>
+      {
+        test.identical( op.exitCode, 0 );
+        test.identical( op.ended, true );
+        test.equivalent( op.output, '[]' );
+        test.is( a.fileProvider.fileExists( testAppPath ) );
+        return null;
+      } )
+
       /* ORIGINAL */
       // return _.process.startNjsPassingThrough( o )
       // .then( ( op ) =>
@@ -6629,24 +6639,14 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
       //   return null;
       // })
 
-      return _.process.start( o2 )
-      .then( ( op ) =>
-      {
-        test.identical( op.exitCode, 0 );
-        test.identical( op.ended, true );
-        test.equivalent( op.output, '[]' );
-        test.is( a.fileProvider.fileExists( testAppPath ) );
-        return null;
-      } )
-  
     });
-  
+
     /* */
-  
+
     ready.then( () =>
     {
       test.case = `mode : ${mode}, execute simple js program with nativized path`
-  
+
       let o =
       {
         execPath : mode === 'fork' ? _.strQuote( testAppPath ) : 'node ' + _.strQuote( testAppPath ),
@@ -6660,7 +6660,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
       };
 
       a.fileProvider.fileWrite({ filePath : a.abs( 'op.json' ), data : o, encoding : 'json' })
-  
+
       let o2 =
       {
         execPath : 'node ' + testAppPathParent,
@@ -6677,7 +6677,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
         test.is( a.fileProvider.fileExists( testAppPath ) );
         return null;
       } )
-  
+
       /* ORIGINAL */
       // return _.process.startNjsPassingThrough( o )
       // .then( ( op ) =>
@@ -6693,7 +6693,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
     ready.then( () =>
     {
       test.case = `mode : ${mode}, execute simple js program with normalized path, parent args : [ 'arg' ]`
-  
+
       let execPath = a.path.nativize( a.path.normalize( testAppPath ) );
       let o =
       {
@@ -6708,7 +6708,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
         applyingExitCode : 0,
       };
       a.fileProvider.fileWrite({ filePath : a.abs( 'op.json' ), data : o, encoding : 'json' })
-  
+
       let o2 =
       {
         execPath : 'node ' + testAppPathParent,
@@ -6725,15 +6725,15 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
         test.is( a.fileProvider.fileExists( testAppPath ) );
         return null;
       } )
-  
+
     });
-  
+
     /* */
-  
+
     ready.then( () =>
     {
       test.case = `mode : ${mode}, execute simple js program with nativized path, parent args : [ 'arg' ]`
-  
+
       let o =
       {
         execPath : mode === 'fork' ? _.strQuote( testAppPath ) : 'node ' + _.strQuote( testAppPath ),
@@ -6748,7 +6748,7 @@ function startNjsPassingThroughDifferentTypesOfPaths( test )
       };
 
       a.fileProvider.fileWrite({ filePath : a.abs( 'op.json' ), data : o, encoding : 'json' })
-  
+
       let o2 =
       {
         execPath : 'node ' + testAppPathParent,
@@ -6834,7 +6834,7 @@ function startPassingThroughExecPathWithSpace( test ) /* qqq for Yevhen : subrou
         throwingExitCode : 0,
         stdio : 'pipe',
       }
-    
+
       return _.process.start( o2 )
       .then( ( op ) =>
       {
@@ -6848,7 +6848,7 @@ function startPassingThroughExecPathWithSpace( test ) /* qqq for Yevhen : subrou
     })
 
     /* */
-  
+
     ready.then( () =>
     {
       test.case = `mode : ${mode}, args is a string with unquoted path with space`


### PR DESCRIPTION
1. Changed & extended test routine `startNjsPassingThroughDifferentTypesOfPaths`. 
2. Changed & extended test routine `startNjsPassingThroughExecPathWithSpace`. 
3. Changed & extended test routine `startPassingThroughExecPathWithSpace`. 
/* qqq for Yevhen : find all tests with passingThrough:1, separate them from the rest of the test
and rewrite to run process which run process to avoid influence of arguments of tester on testing
qqq2 : not done
*/