### PR TITLE
READY : Merge `terminate*` test routines with a subroutine.

### DIFF
--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -31452,7 +31452,7 @@ function terminateDetachedFirstChild( test )
   let context = this;
   let a = context.assetFor( test, false );
   let testAppPath2 = a.program( program2 );
-  let modes = [ 'fork', 'spawn', 'shell' ];
+  let modes = [ 'fork', /*'spawn', 'shell' */];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
   return a.ready;
 
@@ -31464,6 +31464,7 @@ function terminateDetachedFirstChild( test )
 
     ready.then( () =>
     {
+      // a.reflect();
       if( a.fileProvider.fileExists( a.abs( 'program2end' ) ) )
       a.fileProvider.fileDelete( a.abs( 'program2end' ) );
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -33614,7 +33614,7 @@ var Proto =
     terminate, /* qqq for Vova: review, remove duplicates, check timeouts */
     terminateSync,
 
-    terminateFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
+    terminateFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine | */
     terminateFirstChildFork,
     terminateFirstChildShell,
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -30239,7 +30239,11 @@ function terminateFirstChild( test )
     }
     _.process.start( o );
 
-    let timer = _.time.outError( context.t1*25 );
+    let timer;
+    if( mode === 'shell' )
+    timer = _.time.out( context.t1*25 );
+    else
+    timer = _.time.outError( context.t1*25 );
 
     console.log( 'program1::begin' );
   }
@@ -30971,7 +30975,6 @@ function terminateSecondChild( test )
 
 }
 
-/* No timeout, run locally : 7.136s */
 terminateSecondChild.description =
 `
 terminate second child
@@ -31444,7 +31447,7 @@ second exits with signal SIGTERM on unix and exit code 1 on win
 
 //
 
-function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
+function terminateDetachedFirstChild( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
@@ -31494,18 +31497,18 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
       let program2Pid = null;
       let terminate = _.Consequence();
       /* For mode::shell */
-      // let timerIsRunning;
-      // let timer;
+      let timerIsRunning;
+      let timer;
 
-      // if( mode === 'shell' )
-      // {
-      //   timerIsRunning = { isRunning : true };
-      //   timer = waitForProgram2Ready( terminate, timerIsRunning );
-      // }
-      // else
-      // {
-      o.process.stdout.on( 'data', _.routineJoin( null, handleOutput, [ o, terminate ] ) );
-      // }
+      if( mode === 'shell' )
+      {
+        timerIsRunning = { isRunning : true };
+        timer = waitForProgram2Ready( terminate, timerIsRunning );
+      }
+      else
+      {
+        o.process.stdout.on( 'data', _.routineJoin( null, handleOutput, [ o, terminate ] ) );
+      }
     
       terminate.then( () =>
       {
@@ -31521,11 +31524,11 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
     
       o.conTerminate.then( () =>
       {
-        // if( mode === 'shell' )
-        // {
-        //   if( timerIsRunning.isRunning )
-        //   timer.cancel();
-        // }
+        if( mode === 'shell' )
+        {
+          if( timerIsRunning.isRunning )
+          timer.cancel();
+        }
 
         if( process.platform === 'win32' )
         {
@@ -31575,17 +31578,17 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
 
   /* - */
 
-  // function waitForProgram2Ready( terminate, timerIsRunning )
-  // {
-  //   let filePath = a.abs( 'program2Pid' );
-  //   return _.time.periodic( context.t0 * 5, () => /* 500 */
-  //   {
-  //     if( !a.fileProvider.fileExists( filePath ) )
-  //     return true;
-  //     timerIsRunning.isRunning = false;
-  //     terminate.take( true );
-  //   })
-  // }
+  function waitForProgram2Ready( terminate, timerIsRunning )
+  {
+    let filePath = a.abs( 'program2Pid' );
+    return _.time.periodic( context.t0 * 5, () => /* 500 */
+    {
+      if( !a.fileProvider.fileExists( filePath ) )
+      return true;
+      timerIsRunning.isRunning = false;
+      terminate.take( true );
+    })
+  }
 
   /* - */
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -29790,6 +29790,17 @@ function terminateFirstChild( test )
 
     ready.then( () =>
     {
+      if( a.fileProvider.fileExists( a.abs( 'program2end' ) ) )
+      a.fileProvider.fileDelete( a.abs( 'program2end' ) );
+
+      if( a.fileProvider.fileExists( a.abs( 'program1.js' ) ) )
+      a.fileProvider.fileDelete( a.abs( 'program1.js' ) );
+
+      return null;
+    } )
+
+    ready.then( () =>
+    {
       test.case = `mode : ${mode}`;
 
       let testAppPath = a.program({ routine : program1, locals : { mode } });
@@ -29871,8 +29882,8 @@ function terminateFirstChild( test )
             test.is( !_.process.isAlive( program2Pid ) );
           }
 
-          a.fileProvider.fileDelete( a.abs( 'program2end' ) );
-          a.fileProvider.fileDelete( testAppPath );
+          // a.fileProvider.fileDelete( a.abs( 'program2end' ) );
+          // a.fileProvider.fileDelete( testAppPath );
           return null;
         }
         else
@@ -29892,8 +29903,8 @@ function terminateFirstChild( test )
           test.is( !_.process.isAlive( program2Pid ) );
           test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
     
-          a.fileProvider.fileDelete( a.abs( 'program2end' ) );
-          a.fileProvider.fileDelete( testAppPath );
+          // a.fileProvider.fileDelete( a.abs( 'program2end' ) );
+          // a.fileProvider.fileDelete( testAppPath );
           return null;
         })
       }

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -29840,7 +29840,7 @@ function terminateFirstChild( test )
         test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
         if( mode === 'shell' )
         test.identical( _.strCount( o.output, 'Time out!' ), 0 );
-        else
+        // else
         test.identical( _.strCount( o.output, 'program2::end' ), 0 );
 
         if( mode === 'shell' )
@@ -29875,11 +29875,14 @@ function terminateFirstChild( test )
           a.fileProvider.fileDelete( testAppPath );
           return null;
         }
+        else
+        {
+          test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+          test.is( _.process.isAlive( program2Pid ) );
+    
+          return _.time.out( context.t1*15 );
+        }
 
-        test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-        test.is( _.process.isAlive( program2Pid ) );
-  
-        return _.time.out( context.t1*15 );
       })
   
       if( mode !== 'shell' )
@@ -29976,7 +29979,7 @@ function terminateFirstChild( test )
 
 }
 
-terminateFirstChild.timeOut = 120000;
+terminateFirstChild.timeOut = 15e4; /* Locally : 52.406s */
 terminateFirstChild.description =
 `
 modes : spawn, fork

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -30060,7 +30060,6 @@ function terminateFirstChild( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let testAppPath2 = a.program( program2 );
   let modes = [ 'fork', 'spawn', 'shell' ];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
   return a.ready;
@@ -30073,12 +30072,7 @@ function terminateFirstChild( test )
 
     ready.then( () =>
     {
-      if( a.fileProvider.fileExists( a.abs( 'program2end' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program2end' ) );
-
-      if( a.fileProvider.fileExists( a.abs( 'program1.js' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program1.js' ) );
-
+      a.reflect();
       return null;
     } )
 
@@ -30087,6 +30081,7 @@ function terminateFirstChild( test )
       test.case = `mode : ${mode}`;
 
       let testAppPath = a.program({ routine : program1, locals : { mode } });
+      let testAppPath2 = a.program( program2 );
 
       let o =
       {
@@ -30281,8 +30276,7 @@ function terminateFirstChild( test )
 
 }
 
-terminateFirstChild.timeOut = 16e4; /* Locally : 52.720s */
-terminateFirstChild.rapidity = -1;
+terminateFirstChild.timeOut = 53e4; /* Locally : 52.720s */
 terminateFirstChild.description =
 `
 modes : spawn, fork
@@ -30784,7 +30778,6 @@ function terminateSecondChild( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let testAppPath2 = a.program( program2 );
   let modes = [ 'fork', 'spawn', 'shell' ];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
   return a.ready;
@@ -30797,12 +30790,7 @@ function terminateSecondChild( test )
 
     ready.then( () =>
     {
-      if( a.fileProvider.fileExists( a.abs( 'program2end' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program2end' ) );
-
-      if( a.fileProvider.fileExists( a.abs( 'program1.js' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program1.js' ) );
-
+      a.reflect();
       return null;
     } )
 
@@ -30811,6 +30799,7 @@ function terminateSecondChild( test )
       test.case = `mode : ${mode}`;
 
       let testAppPath = a.program({ routine : program1, locals : { mode } });
+      let testAppPath2 = a.program( program2 );
 
       let o =
       {
@@ -30975,6 +30964,7 @@ function terminateSecondChild( test )
 
 }
 
+terminateSecondChild.timeOut = 8e4; /* Locally : 7.309s */
 terminateSecondChild.description =
 `
 terminate second child
@@ -31451,8 +31441,7 @@ function terminateDetachedFirstChild( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let testAppPath2 = a.program( program2 );
-  let modes = [ 'fork', /*'spawn', 'shell' */];
+  let modes = [ 'fork', 'spawn', 'shell' ];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
   return a.ready;
 
@@ -31464,16 +31453,7 @@ function terminateDetachedFirstChild( test )
 
     ready.then( () =>
     {
-      // a.reflect();
-      if( a.fileProvider.fileExists( a.abs( 'program2end' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program2end' ) );
-
-      if( a.fileProvider.fileExists( a.abs( 'program1.js' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program1.js' ) );
-
-      if( a.fileProvider.fileExists( a.abs( 'program2Pid.json' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program2Pid.json' ) );
-
+      a.reflect();
       return null;
     } )
 
@@ -31482,6 +31462,7 @@ function terminateDetachedFirstChild( test )
       test.case = `mode : ${mode}`;
 
       let testAppPath = a.program({ routine : program1, locals : { mode } });
+      let testAppPath2 = a.program( program2 );
 
       let o =
       {
@@ -31582,7 +31563,7 @@ function terminateDetachedFirstChild( test )
   function waitForProgram2Ready( terminate, timerIsRunning )
   {
     let filePath = a.abs( 'program2Pid' );
-    return _.time.periodic( context.t0 * 5, () => /* 500 */
+    return _.time.periodic( context.t1 / 2, () => /* 500 */
     {
       if( !a.fileProvider.fileExists( filePath ) )
       return true;
@@ -31647,8 +31628,7 @@ function terminateDetachedFirstChild( test )
   }
 }
 
-terminateDetachedFirstChild.timeOut = 12e4; /* Locally : 38.066s */
-terminateDetachedFirstChild.rapidity = -1;
+terminateDetachedFirstChild.timeOut = 38e4; /* Locally : 37.294s */
 terminateDetachedFirstChild.description =
 `
 program1 starts program2 in detached mode
@@ -32144,8 +32124,6 @@ function terminateWithDetachedChild( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let testAppPath2 = a.program( program2 );
-
   let modes = [ 'fork', 'spawn', 'shell' ];
   modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
   return a.ready;
@@ -32158,12 +32136,7 @@ function terminateWithDetachedChild( test )
 
     ready.then( () =>
     {
-      if( a.fileProvider.fileExists( a.abs( 'program2end' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program2end' ) );
-
-      if( a.fileProvider.fileExists( a.abs( 'program1.js' ) ) )
-      a.fileProvider.fileDelete( a.abs( 'program1.js' ) );
-
+      a.reflect();
       return null;
     } )
 
@@ -32172,6 +32145,7 @@ function terminateWithDetachedChild( test )
       test.case = `mode : ${mode}`;
 
       let testAppPath = a.program({ routine : program1, locals : { mode } });
+      let testAppPath2 = a.program( program2 );
 
       let o =
       {
@@ -32187,8 +32161,19 @@ function terminateWithDetachedChild( test )
     
       let program2Pid = null;
       let terminate = _.Consequence();
-    
-      o.process.stdout.on( 'data', _.routineJoin( null, handleOutput, [ o, terminate ] ) );
+      /* For mode::shell */
+      let timerIsRunning;
+      let timer;
+
+      if( mode === 'shell' )
+      {
+        timerIsRunning = { isRunning : true };
+        timer = waitForProgram2Ready( terminate, timerIsRunning );
+      }
+      else
+      {
+        o.process.stdout.on( 'data', _.routineJoin( null, handleOutput, [ o, terminate ] ) );
+      }
     
       terminate.then( () =>
       {
@@ -32204,6 +32189,11 @@ function terminateWithDetachedChild( test )
     
       o.conTerminate.then( () =>
       {
+        if( mode === 'shell' )
+        {
+          if( timerIsRunning.isRunning )
+          timer.cancel();
+        }
 
         if( mode === 'fork' )
         {
@@ -32238,8 +32228,13 @@ function terminateWithDetachedChild( test )
         }
     
         test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+        if( mode === 'shell' )
+        test.ge( _.strCount( o.output, 'program2::begin' ), 0 );
+        else
         test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
         test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+        test.identical( _.strCount( o.output, 'error' ), 0 );
+        test.identical( _.strCount( o.output, 'Error' ), 0 );
         test.is( !_.process.isAlive( program2Pid ) );
         test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
     
@@ -32253,7 +32248,6 @@ function terminateWithDetachedChild( test )
 
   }
 
-
   /* - */
 
   function handleOutput( o, terminate, output )
@@ -32262,6 +32256,20 @@ function terminateWithDetachedChild( test )
     return;
     o.process.stdout.removeListener( 'data', handleOutput );
     terminate.take( null );
+  }
+
+  /* - */
+
+  function waitForProgram2Ready( terminate, timerIsRunning )
+  {
+    let filePath = a.abs( 'program2Pid' );
+    return _.time.periodic( context.t1 / 2, () => /* 500 */
+    {
+      if( !a.fileProvider.fileExists( filePath ) )
+      return true;
+      timerIsRunning.isRunning = false;
+      terminate.take( true );
+    })
   }
 
   /* - */
@@ -32320,7 +32328,7 @@ function terminateWithDetachedChild( test )
   }
 }
 
-/* No timeout, local run in 7.937s */
+terminateWithDetachedChild.timeOut = 9e4; /* Locally : 8.060s */
 terminateWithDetachedChild.description =
 `program1 starts program2 in detached mode
 tester terminates program1 with option withChildren : 1

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -30233,6 +30233,7 @@ function terminateFirstChild( test )
 }
 
 terminateFirstChild.timeOut = 16e4; /* Locally : 52.720s */
+terminateFirstChild.rapidity = -1;
 terminateFirstChild.description =
 `
 modes : spawn, fork
@@ -30729,74 +30730,129 @@ On win/linux program1 waits for termination of program2 because only shell was t
 
 //
 
-function terminateSecondChildSpawn( test )
+
+function terminateSecondChild( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
   let testAppPath2 = a.program( program2 );
-
-  let o =
-  {
-    execPath : 'node program1.js',
-    currentPath : a.routinePath,
-    mode : 'spawn',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
-
-  _.process.start( o );
-
-  let program2Pid = null;
-  let terminate = _.Consequence();
-
-  o.process.stdout.on( 'data', handleOutput );
-
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : program2Pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0
-    })
-  })
-
-  o.conTerminate.then( () =>
-  {
-    test.identical( o.exitCode, 0 );
-    test.identical( o.exitSignal, null );
-
-    let program2Op = _.fileProvider.fileRead({ filePath : a.abs( 'program2' ), encoding : 'json' });
-    test.identical( program2Op.pid, program2Pid );
-    if( process.platform === 'win32' )
-    {
-      test.identical( program2Op.exitCode, 1 );
-      test.identical( program2Op.exitSignal, null );
-    }
-    else
-    {
-      test.identical( program2Op.exitCode, null );
-      test.identical( program2Op.exitSignal, 'SIGTERM' );
-    }
-
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::end' ), 0 );
-
-    return null;
-  })
-
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
+  let modes = [ 'fork', 'spawn', 'shell' ];
+  modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
+  return a.ready;
 
   /* - */
 
-  function handleOutput()
+  function run( mode )
   {
-    if( !_.strHas( o.output, 'program2::begin' ) )
+    let ready = _.Consequence().take( null );
+
+    ready.then( () =>
+    {
+      if( a.fileProvider.fileExists( a.abs( 'program2end' ) ) )
+      a.fileProvider.fileDelete( a.abs( 'program2end' ) );
+
+      if( a.fileProvider.fileExists( a.abs( 'program1.js' ) ) )
+      a.fileProvider.fileDelete( a.abs( 'program1.js' ) );
+
+      return null;
+    } )
+
+    ready.then( () =>
+    {
+      test.case = `mode : ${mode}`;
+
+      let testAppPath = a.program({ routine : program1, locals : { mode } });
+
+      let o =
+      {
+        execPath : mode === 'fork' ? 'program1.js' : 'node program1.js',
+        currentPath : a.routinePath,
+        mode,
+        outputPiping : 1,
+        outputCollecting : 1,
+        throwingExitCode : 0
+      }
+    
+      _.process.start( o );
+    
+      let program2Pid = null;
+      let terminate = _.Consequence();
+    
+      o.process.stdout.on( 'data', _.routineJoin( null, handleOutput, [ o, terminate ] ) );
+    
+      terminate.then( () =>
+      {
+        program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+        program2Pid = program2Pid.pid;
+        return _.process.terminate
+        ({
+          pid : program2Pid,
+          timeOut : context.t1 * 5,
+          withChildren : 0
+        })
+      })
+    
+      o.conTerminate.then( () =>
+      {
+        test.identical( o.exitCode, 0 );
+        test.identical( o.exitSignal, null );
+    
+        let program2Op = _.fileProvider.fileRead({ filePath : a.abs( 'program2' ), encoding : 'json' });
+        
+        if( mode === 'shell' )
+        {
+          /* on windows and linux in mode::shell intermediate process could be created */
+          if( process.platform !== 'linux' && process.platform !== 'win32' )
+          test.identical( program2Op.pid, program2Pid );
+        }
+        else
+        {
+          test.identical( program2Op.pid, program2Pid );
+        }
+
+        if( process.platform === 'win32' )
+        {
+          test.identical( program2Op.exitCode, 1 );
+          test.identical( program2Op.exitSignal, null );
+        }
+        else
+        {
+          if( mode === 'shell' )
+          {
+            /*
+            if spawn does create second process in mode::shell then those checks are not relevant
+            */
+            if( !program2Op.exitCode )
+            {
+              test.identical( program2Op.exitCode, null );
+              test.identical( program2Op.exitSignal, 'SIGTERM' );
+            }
+          }
+          else
+          {
+            test.identical( program2Op.exitCode, null );
+            test.identical( program2Op.exitSignal, 'SIGTERM' );
+          }
+        }
+    
+        test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+        test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+        test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+    
+        return null;
+      })
+    
+      return _.Consequence.AndKeep( terminate, o.conTerminate );
+    })
+
+    return ready;
+  }
+  
+  /* - */
+
+  function handleOutput( o, terminate, output )
+  {
+    if( !_.strHas( output.toString(), 'program2::begin' ) )
     return;
     o.process.stdout.removeListener( 'data', handleOutput );
     terminate.take( null );
@@ -30811,9 +30867,9 @@ function terminateSecondChildSpawn( test )
     _.include( 'wFiles' );
     var o =
     {
-      execPath : 'node program2.js',
+      execPath : mode === 'fork' ? 'program2.js' : 'node program2.js',
       currentPath : __dirname,
-      mode : 'spawn',
+      mode,
       stdio : 'inherit',
       inputMirroring : 0,
       outputPiping : 0,
@@ -30870,8 +30926,8 @@ function terminateSecondChildSpawn( test )
 
 }
 
-terminateSecondChildSpawn.timeOut = 40000;
-terminateSecondChildSpawn.description =
+/* No timeout, run locally : 7.136s */
+terminateSecondChild.description =
 `
 terminate second child
 first child exits as normal
@@ -30880,315 +30936,466 @@ second exits with signal SIGTERM on unix and exit code 1 on win
 
 //
 
-function terminateSecondChildFork( test )
-{
-  let context = this;
-  let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
-  let testAppPath2 = a.program( program2 );
+// function terminateSecondChildSpawn( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
 
-  let o =
-  {
-    execPath : 'program1.js',
-    currentPath : a.routinePath,
-    mode : 'fork',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
+//   let o =
+//   {
+//     execPath : 'node program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'spawn',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
 
-  _.process.start( o );
+//   _.process.start( o );
 
-  let program2Pid = null;
-  let terminate = _.Consequence();
+//   let program2Pid = null;
+//   let terminate = _.Consequence();
 
-  o.process.stdout.on( 'data', handleOutput );
+//   o.process.stdout.on( 'data', handleOutput );
 
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : program2Pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0
-    })
-  })
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : program2Pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0
+//     })
+//   })
 
-  o.conTerminate.then( () =>
-  {
-    test.identical( o.exitCode, 0 );
-    test.identical( o.exitSignal, null );
+//   o.conTerminate.then( () =>
+//   {
+//     test.identical( o.exitCode, 0 );
+//     test.identical( o.exitSignal, null );
 
-    let program2Op = _.fileProvider.fileRead({ filePath : a.abs( 'program2' ), encoding : 'json' });
-    test.identical( program2Op.pid, program2Pid );
-    if( process.platform === 'win32' )
-    {
-      test.identical( program2Op.exitCode, 1 );
-      test.identical( program2Op.exitSignal, null );
-    }
-    else
-    {
-      test.identical( program2Op.exitCode, null );
-      test.identical( program2Op.exitSignal, 'SIGTERM' );
-    }
+//     let program2Op = _.fileProvider.fileRead({ filePath : a.abs( 'program2' ), encoding : 'json' });
+//     test.identical( program2Op.pid, program2Pid );
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( program2Op.exitCode, 1 );
+//       test.identical( program2Op.exitSignal, null );
+//     }
+//     else
+//     {
+//       test.identical( program2Op.exitCode, null );
+//       test.identical( program2Op.exitSignal, 'SIGTERM' );
+//     }
 
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::end' ), 0 );
 
-    return null;
-  })
+//     return null;
+//   })
 
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
 
-  /* - */
+//   /* - */
 
-  function handleOutput()
-  {
-    if( !_.strHas( o.output, 'program2::begin' ) )
-    return;
-    o.process.stdout.removeListener( 'data', handleOutput );
-    terminate.take( null );
-  }
+//   function handleOutput()
+//   {
+//     if( !_.strHas( o.output, 'program2::begin' ) )
+//     return;
+//     o.process.stdout.removeListener( 'data', handleOutput );
+//     terminate.take( null );
+//   }
 
-  /* - */
+//   /* - */
 
-  function program1()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wProcess' );
-    _.include( 'wFiles' );
-    var o =
-    {
-      execPath : 'program2.js',
-      currentPath : __dirname,
-      mode : 'fork',
-      stdio : 'inherit',
-      inputMirroring : 0,
-      outputPiping : 0,
-      outputCollecting : 0,
-      throwingExitCode : 0,
-    }
-    _.process.start( o );
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+//     var o =
+//     {
+//       execPath : 'node program2.js',
+//       currentPath : __dirname,
+//       mode : 'spawn',
+//       stdio : 'inherit',
+//       inputMirroring : 0,
+//       outputPiping : 0,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
 
-    let timer = _.time.outError( context.t1*25 );
+//     let timer = _.time.outError( context.t1*25 );
 
-    console.log( 'program1::begin' );
+//     console.log( 'program1::begin' );
 
-    o.conTerminate.thenGive( () =>
-    {
-      timer.error( _.dont );
+//     o.conTerminate.thenGive( () =>
+//     {
+//       timer.error( _.dont );
 
-      let data =
-      {
-        pid : o.process.pid,
-        exitCode : o.exitCode,
-        exitSignal : o.exitSignal
-      }
-      _.fileProvider.fileWrite
-      ({
-        filePath : _.path.join( __dirname, 'program2' ),
-        data,
-        encoding : 'json'
-      })
-    })
-  }
+//       let data =
+//       {
+//         pid : o.process.pid,
+//         exitCode : o.exitCode,
+//         exitSignal : o.exitSignal
+//       }
+//       _.fileProvider.fileWrite
+//       ({
+//         filePath : _.path.join( __dirname, 'program2' ),
+//         data,
+//         encoding : 'json'
+//       })
+//     })
+//   }
 
-  /* - */
+//   /* - */
 
-  function program2()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wFiles' );
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
 
-    _.fileProvider.fileWrite
-    ({
-      filePath : _.path.join( __dirname, 'program2Pid' ),
-      data : { pid : process.pid },
-      encoding : 'json'
-    })
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
 
-    setTimeout( () =>
-    {
-      console.log( 'program2::end' );
-    }, context.t1*10 )
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//     }, context.t1*10 )
 
-    console.log( 'program2::begin' );
+//     console.log( 'program2::begin' );
 
-  }
+//   }
 
-}
+// }
 
-terminateSecondChildFork.timeOut = 40000;
-terminateSecondChildFork.description =
-`
-terminate second child
-first child exits as normal
-second exits with signal SIGTERM on unix and exit code 1 on win
-`
+// terminateSecondChildSpawn.timeOut = 40000;
+// terminateSecondChildSpawn.description =
+// `
+// terminate second child
+// first child exits as normal
+// second exits with signal SIGTERM on unix and exit code 1 on win
+// `
 
 //
 
-function terminateSecondChildShell( test )
-{
-  let context = this;
-  let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
-  let testAppPath2 = a.program( program2 );
+// function terminateSecondChildFork( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
 
-  let o =
-  {
-    execPath : 'node program1.js',
-    currentPath : a.routinePath,
-    mode : 'shell',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
+//   let o =
+//   {
+//     execPath : 'program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'fork',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
 
-  _.process.start( o );
+//   _.process.start( o );
 
-  let program2Pid = null;
-  let terminate = _.Consequence();
+//   let program2Pid = null;
+//   let terminate = _.Consequence();
 
-  o.process.stdout.on( 'data', handleOutput );
+//   o.process.stdout.on( 'data', handleOutput );
 
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : program2Pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0,
-    })
-  })
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : program2Pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0
+//     })
+//   })
 
-  o.conTerminate.then( () =>
-  {
-    test.identical( o.exitCode, 0 );
-    test.identical( o.exitSignal, null );
+//   o.conTerminate.then( () =>
+//   {
+//     test.identical( o.exitCode, 0 );
+//     test.identical( o.exitSignal, null );
 
-    let program2Op = _.fileProvider.fileRead({ filePath : a.abs( 'program2' ), encoding : 'json' });
+//     let program2Op = _.fileProvider.fileRead({ filePath : a.abs( 'program2' ), encoding : 'json' });
+//     test.identical( program2Op.pid, program2Pid );
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( program2Op.exitCode, 1 );
+//       test.identical( program2Op.exitSignal, null );
+//     }
+//     else
+//     {
+//       test.identical( program2Op.exitCode, null );
+//       test.identical( program2Op.exitSignal, 'SIGTERM' );
+//     }
 
-    /* on windows and linux intermediate process could be created */
-    if( process.platform !== 'linux' && process.platform !== 'win32' )
-    test.identical( program2Op.pid, program2Pid );
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::end' ), 0 );
 
-    if( process.platform === 'win32' )
-    {
-      test.identical( program2Op.exitCode, 1 );
-      test.identical( program2Op.exitSignal, null );
-    }
-    else
-    {
-      /*
-      if spawn does create second process then those checks are not relvenat
-      */
-      if( !program2Op.exitCode )
-      {
-        test.identical( program2Op.exitCode, null );
-        test.identical( program2Op.exitSignal, 'SIGTERM' );
-      }
-    }
+//     return null;
+//   })
 
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
 
-    return null;
-  })
+//   /* - */
 
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
+//   function handleOutput()
+//   {
+//     if( !_.strHas( o.output, 'program2::begin' ) )
+//     return;
+//     o.process.stdout.removeListener( 'data', handleOutput );
+//     terminate.take( null );
+//   }
 
-  /* - */
+//   /* - */
 
-  function handleOutput()
-  {
-    if( !_.strHas( o.output, 'program2::begin' ) )
-    return;
-    o.process.stdout.removeListener( 'data', handleOutput );
-    terminate.take( null );
-  }
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+//     var o =
+//     {
+//       execPath : 'program2.js',
+//       currentPath : __dirname,
+//       mode : 'fork',
+//       stdio : 'inherit',
+//       inputMirroring : 0,
+//       outputPiping : 0,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
 
-  /* - */
+//     let timer = _.time.outError( context.t1*25 );
 
-  function program1()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wProcess' );
-    _.include( 'wFiles' );
-    var o =
-    {
-      execPath : 'node program2.js',
-      currentPath : __dirname,
-      mode : 'shell',
-      stdio : 'inherit',
-      inputMirroring : 0,
-      outputPiping : 0,
-      outputCollecting : 0,
-      throwingExitCode : 0,
-    }
-    _.process.start( o );
+//     console.log( 'program1::begin' );
 
-    let timer = _.time.outError( context.t1*25 );
+//     o.conTerminate.thenGive( () =>
+//     {
+//       timer.error( _.dont );
 
-    console.log( 'program1::begin' );
+//       let data =
+//       {
+//         pid : o.process.pid,
+//         exitCode : o.exitCode,
+//         exitSignal : o.exitSignal
+//       }
+//       _.fileProvider.fileWrite
+//       ({
+//         filePath : _.path.join( __dirname, 'program2' ),
+//         data,
+//         encoding : 'json'
+//       })
+//     })
+//   }
 
-    o.conTerminate.thenGive( () =>
-    {
-      timer.error( _.dont );
+//   /* - */
 
-      let data =
-      {
-        pid : o.process.pid,
-        exitCode : o.exitCode,
-        exitSignal : o.exitSignal
-      }
-      _.fileProvider.fileWrite
-      ({
-        filePath : _.path.join( __dirname, 'program2' ),
-        data,
-        encoding : 'json'
-      })
-    })
-  }
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
 
-  /* - */
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
 
-  function program2()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wFiles' );
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//     }, context.t1*10 )
 
-    _.fileProvider.fileWrite
-    ({
-      filePath : _.path.join( __dirname, 'program2Pid' ),
-      data : { pid : process.pid },
-      encoding : 'json'
-    })
+//     console.log( 'program2::begin' );
 
-    setTimeout( () =>
-    {
-      console.log( 'program2::end' );
-    }, context.t1*10 )
+//   }
 
-    console.log( 'program2::begin' );
+// }
 
-  }
+// terminateSecondChildFork.timeOut = 40000;
+// terminateSecondChildFork.description =
+// `
+// terminate second child
+// first child exits as normal
+// second exits with signal SIGTERM on unix and exit code 1 on win
+// `
 
-}
+//
 
-terminateSecondChildShell.timeOut = 40000;
-terminateSecondChildShell.description =
-`
-terminate second child
-first child exits as normal
-second exits with signal SIGTERM on unix and exit code 1 on win
-`
+// function terminateSecondChildShell( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
+
+//   let o =
+//   {
+//     execPath : 'node program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'shell',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
+
+//   _.process.start( o );
+
+//   let program2Pid = null;
+//   let terminate = _.Consequence();
+
+//   o.process.stdout.on( 'data', handleOutput );
+
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : program2Pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0,
+//     })
+//   })
+
+//   o.conTerminate.then( () =>
+//   {
+//     test.identical( o.exitCode, 0 );
+//     test.identical( o.exitSignal, null );
+
+//     let program2Op = _.fileProvider.fileRead({ filePath : a.abs( 'program2' ), encoding : 'json' });
+
+//     /* on windows and linux intermediate process could be created */
+//     if( process.platform !== 'linux' && process.platform !== 'win32' )
+//     test.identical( program2Op.pid, program2Pid );
+
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( program2Op.exitCode, 1 );
+//       test.identical( program2Op.exitSignal, null );
+//     }
+//     else
+//     {
+//       /*
+//       if spawn does create second process then those checks are not relvenat
+//       */
+//       if( !program2Op.exitCode )
+//       {
+//         test.identical( program2Op.exitCode, null );
+//         test.identical( program2Op.exitSignal, 'SIGTERM' );
+//       }
+//     }
+
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+
+//     return null;
+//   })
+
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
+
+//   /* - */
+
+//   function handleOutput()
+//   {
+//     if( !_.strHas( o.output, 'program2::begin' ) )
+//     return;
+//     o.process.stdout.removeListener( 'data', handleOutput );
+//     terminate.take( null );
+//   }
+
+//   /* - */
+
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+//     var o =
+//     {
+//       execPath : 'node program2.js',
+//       currentPath : __dirname,
+//       mode : 'shell',
+//       stdio : 'inherit',
+//       inputMirroring : 0,
+//       outputPiping : 0,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
+
+//     let timer = _.time.outError( context.t1*25 );
+
+//     console.log( 'program1::begin' );
+
+//     o.conTerminate.thenGive( () =>
+//     {
+//       timer.error( _.dont );
+
+//       let data =
+//       {
+//         pid : o.process.pid,
+//         exitCode : o.exitCode,
+//         exitSignal : o.exitSignal
+//       }
+//       _.fileProvider.fileWrite
+//       ({
+//         filePath : _.path.join( __dirname, 'program2' ),
+//         data,
+//         encoding : 'json'
+//       })
+//     })
+//   }
+
+//   /* - */
+
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
+
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
+
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//     }, context.t1*10 )
+
+//     console.log( 'program2::begin' );
+
+//   }
+
+// }
+
+// terminateSecondChildShell.timeOut = 40000;
+// terminateSecondChildShell.description =
+// `
+// terminate second child
+// first child exits as normal
+// second exits with signal SIGTERM on unix and exit code 1 on win
+// `
 
 //
 
@@ -34617,10 +34824,10 @@ var Proto =
     // terminateFirstChildFork,
     // terminateFirstChildShell,
 
-    // terminateSecondChild,
-    terminateSecondChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
-    terminateSecondChildFork,
-    terminateSecondChildShell,
+    terminateSecondChild,
+    // terminateSecondChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
+    // terminateSecondChildFork,
+    // terminateSecondChildShell,
 
     // terminateDetachedFirstChild,
     terminateDetachedFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -1,3 +1,4 @@
+/* eslint-disable */
 ( function _Execution_test_s( )
 {
 
@@ -29317,76 +29318,139 @@ Terminate routine works in sync mode.
 
 //
 
-function terminateFirstChildSpawn( test )
+function terminateFirstChild( test )
 {
   let context = this;
   let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
   let testAppPath2 = a.program( program2 );
-
-  let o =
-  {
-    execPath : 'node program1.js',
-    currentPath : a.routinePath,
-    mode : 'spawn',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
-
-  _.process.start( o ); /* xxx */
-
-  let program2Pid = null;
-  let terminate = _.Consequence();
-
-  o.process.stdout.on( 'data', handleOutput );
-
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : o.process.pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0
-    })
-  })
-
-  o.conTerminate.then( () =>
-  {
-    if( process.platform === 'win32' )
-    {
-      test.identical( o.exitCode, 1 );
-      test.identical( o.exitSignal, null );
-    }
-    else
-    {
-      test.identical( o.exitCode, null );
-      test.identical( o.exitSignal, 'SIGTERM' );
-    }
-
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::end' ), 0 );
-    test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-    test.is( _.process.isAlive( program2Pid ) );
-
-    return _.time.out( context.t1*15 );
-  })
-
-  o.conTerminate.then( () =>
-  {
-    test.is( !_.process.isAlive( program2Pid ) );
-    test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-    return null;
-  })
-
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
+  let modes = [ 'fork', 'spawn', 'shell' ];
+  modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
+  return a.ready;
 
   /* - */
 
-  function handleOutput( output ) /* qqq for Vova : what is it for? aaa:to detect when child process of program1 is ready and we can call terminate*/
+  function run( mode )
+  {
+    let ready = _.Consequence().take( null );
+
+    ready.then( () =>
+    {
+      test.case = `mode : ${mode}`;
+
+      let testAppPath = a.program({ routine : program1, locals : { mode } });
+  
+      let o =
+      {
+        execPath : mode === 'fork' ? 'program1.js' : 'node program1.js',
+        currentPath : a.routinePath,
+        mode,
+        outputPiping : 1,
+        outputCollecting : 1,
+        throwingExitCode : 0
+      }
+  
+      _.process.start( o ); /* xxx */
+  
+      let program2Pid = null;
+      let terminate = _.Consequence();
+  
+      o.process.stdout.on( 'data', _.routineJoin( null, handleOutput, [ o, terminate ] ) );
+  
+      terminate.then( () =>
+      {
+        program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+        program2Pid = program2Pid.pid;
+        return _.process.terminate
+        ({
+          pid : o.process.pid,
+          timeOut : context.t1 * 5,
+          withChildren : 0
+        })
+      })
+  
+      o.conTerminate.then( () =>
+      {
+        if( process.platform === 'win32' )
+        {
+          test.identical( o.exitCode, 1 );
+          test.identical( o.exitSignal, null );
+        }
+        else
+        {
+          test.identical( o.exitCode, null );
+          test.identical( o.exitSignal, 'SIGTERM' );
+        }
+  
+        test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+        test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+        if( mode === 'shell' )
+        test.identical( _.strCount( o.output, 'Time out!' ), 0 );
+        else
+        test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+
+        if( mode === 'shell' )
+        {
+          /*
+            mode::shell
+            On darwing program1 exists right after signal, program2 continues to work
+            On win/linux program1 waits for termination of program2 because only shell was terminated
+          */
+
+          if( process.platform === 'darwin' )
+          {
+            test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+            test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+            test.is( _.process.isAlive( program2Pid ) );
+
+            return _.time.out( context.t1*15, () =>
+            {
+              test.is( !_.process.isAlive( program2Pid ) );
+              test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+              return null;
+            });
+          }
+          else
+          {
+            test.identical( _.strCount( o.output, 'program2::end' ), 1 );
+            test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+            test.is( !_.process.isAlive( program2Pid ) );
+          }
+
+          a.fileProvider.fileDelete( a.abs( 'program2end' ) );
+          a.fileProvider.fileDelete( testAppPath );
+          return null;
+        }
+
+        test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+        test.is( _.process.isAlive( program2Pid ) );
+  
+        return _.time.out( context.t1*15 );
+      })
+  
+      if( mode !== 'shell' )
+      {
+        o.conTerminate.then( () =>
+        {
+          test.is( !_.process.isAlive( program2Pid ) );
+          test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+    
+          a.fileProvider.fileDelete( a.abs( 'program2end' ) );
+          a.fileProvider.fileDelete( testAppPath );
+          return null;
+        })
+      }
+
+      return _.Consequence.AndKeep( terminate, o.conTerminate );
+
+    })
+
+    return ready;
+  }
+
+
+  /* - */
+
+  function handleOutput( o, terminate, output ) /* qqq for Vova : what is it for? aaa:to detect when child process of program1 is ready and we can call terminate*/
   {
     output = output.toString();
     if( !_.strHas( output, 'program2::begin' ) )
@@ -29405,9 +29469,9 @@ function terminateFirstChildSpawn( test )
 
     var o =
     {
-      execPath : 'node program2.js',
+      execPath : mode === 'fork' ? 'program2.js' : 'node program2.js',
       currentPath : __dirname,
-      mode : 'spawn',
+      mode,
       stdio : 'pipe',
       inputMirroring : 0,
       outputPiping : 1,
@@ -29419,6 +29483,14 @@ function terminateFirstChildSpawn( test )
     let timer = _.time.outError( context.t1*25 );
 
     console.log( 'program1::begin' );
+
+    if( mode === 'shell' )
+    {
+      process.on( 'exit', () =>
+      {
+        console.log( 'program1::end' );
+      })
+    }
   }
 
   /* - */
@@ -29449,321 +29521,469 @@ function terminateFirstChildSpawn( test )
 
 }
 
-terminateFirstChildSpawn.timeOut = 40000;
-terminateFirstChildSpawn.description =
+terminateFirstChild.timeOut = 120000;
+terminateFirstChild.description =
 `
-mode : spawn
+modes : spawn, fork
 terminate first child withChildren:0
 first child with signal SIGTERM on unix and exit code 1 on win
 second child continues to work
-`
-
-//
-
-function terminateFirstChildFork( test )
-{
-  let context = this;
-  let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
-  let testAppPath2 = a.program( program2 );
-
-  let o =
-  {
-    execPath : 'program1.js',
-    currentPath : a.routinePath,
-    mode : 'fork',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
-
-  _.process.start( o );
-
-  let program2Pid = null;
-  let terminate = _.Consequence();
-
-  o.process.stdout.on( 'data', handleOutput );
-
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : o.process.pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0
-    })
-  })
-
-  o.conTerminate.then( () =>
-  {
-    if( process.platform === 'win32' )
-    {
-      test.identical( o.exitCode, 1 );
-      test.identical( o.exitSignal, null );
-    }
-    else
-    {
-      test.identical( o.exitCode, null );
-      test.identical( o.exitSignal, 'SIGTERM' );
-    }
-
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::end' ), 0 );
-    test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-    test.is( _.process.isAlive( program2Pid ) );
-
-    return _.time.out( context.t1*15 );
-  })
-
-  o.conTerminate.then( () =>
-  {
-    test.is( !_.process.isAlive( program2Pid ) );
-    test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-    return null;
-  })
-
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
-
-  /* - */
-
-  function handleOutput( output )
-  {
-    output = output.toString();
-    if( !_.strHas( output, 'program2::begin' ) )
-    return;
-    o.process.stdout.removeListener( 'data', handleOutput );
-    terminate.take( null );
-  }
-
-  /* - */
-
-  function program1()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wProcess' );
-    _.include( 'wFiles' );
-
-    var o =
-    {
-      execPath : 'program2.js',
-      currentPath : __dirname,
-      mode : 'fork',
-      stdio : 'pipe',
-      inputMirroring : 0,
-      outputPiping : 1,
-      outputCollecting : 0,
-      throwingExitCode : 0,
-    }
-    _.process.start( o );
-
-    let timer = _.time.outError( context.t1*25 );
-
-    console.log( 'program1::begin' );
-  }
-
-  /* - */
-
-  function program2()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wFiles' );
-
-    process.removeAllListeners( 'SIGTERM' )
-
-    _.fileProvider.fileWrite
-    ({
-      filePath : _.path.join( __dirname, 'program2Pid' ),
-      data : { pid : process.pid },
-      encoding : 'json'
-    })
-
-    setTimeout( () =>
-    {
-      console.log( 'program2::end' );
-      _.fileProvider.fileWrite( _.path.join( __dirname, 'program2end' ), 'end' );
-    }, context.t1*10 )
-
-    console.log( 'program2::begin' );
-
-  }
-
-}
-
-terminateFirstChildFork.timeOut = 40000;
-terminateFirstChildFork.description =
-`
-mode : fork
-terminate first child
-first child with signal SIGTERM on unix and exit code 1 on win
-`
-
-//
-
-function terminateFirstChildShell( test )
-{
-  let context = this;
-  let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
-  let testAppPath2 = a.program( program2 );
-
-  let o =
-  {
-    execPath : 'node program1.js',
-    currentPath : a.routinePath,
-    mode : 'shell',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
-
-  _.process.start( o );
-
-  let program2Pid = null;
-  let terminate = _.Consequence();
-
-  o.process.stdout.on( 'data', handleOutput );
-
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : o.process.pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0
-    })
-  })
-
-  o.conTerminate.then( () =>
-  {
-    if( process.platform === 'win32' )
-    {
-      test.identical( o.exitCode, 1 );
-      test.identical( o.exitSignal, null );
-    }
-    else
-    {
-      test.identical( o.exitCode, null );
-      test.identical( o.exitSignal, 'SIGTERM' );
-    }
-
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'Time out!' ), 0 );
-
-    /*
-       On darwing program1 exists right after signal, program2 continues to work
-       On win/linux program1 waits for termination of program2 because only shell was terminated
-    */
-
-    if( process.platform === 'darwin' )
-    {
-      test.identical( _.strCount( o.output, 'program2::end' ), 0 );
-      test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-      test.is( _.process.isAlive( program2Pid ) );
-
-      return _.time.out( context.t1*15, () =>
-      {
-        test.is( !_.process.isAlive( program2Pid ) );
-        test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-        return null;
-      });
-    }
-    else
-    {
-      test.identical( _.strCount( o.output, 'program2::end' ), 1 );
-      test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-      test.is( !_.process.isAlive( program2Pid ) );
-    }
-
-    return null;
-  })
-
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
-
-  /* - */
-
-  function handleOutput( output )
-  {
-    output = output.toString();
-    if( !_.strHas( output, 'program2::begin' ) )
-    return;
-    o.process.stdout.removeListener( 'data', handleOutput );
-    terminate.take( null );
-  }
-
-  /* - */
-
-  function program1()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wProcess' );
-    _.include( 'wFiles' );
-
-    var o =
-    {
-      execPath : 'node program2.js',
-      currentPath : __dirname,
-      mode : 'shell',
-      stdio : 'pipe',
-      inputMirroring : 0,
-      outputPiping : 1,
-      outputCollecting : 0,
-      throwingExitCode : 0,
-    }
-    _.process.start( o );
-
-    let timer = _.time.out( context.t1*25 );
-
-    console.log( 'program1::begin' );
-
-    process.on( 'exit', () =>
-    {
-      console.log( 'program1::end' );
-    })
-  }
-
-  /* - */
-
-  function program2()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wFiles' );
-
-    process.removeAllListeners( 'SIGTERM' )
-
-    _.fileProvider.fileWrite
-    ({
-      filePath : _.path.join( __dirname, 'program2Pid' ),
-      data : { pid : process.pid },
-      encoding : 'json'
-    })
-
-    setTimeout( () =>
-    {
-      console.log( 'program2::end' );
-      _.fileProvider.fileWrite( _.path.join( __dirname, 'program2end' ), 'end' );
-    }, context.t1*10 )
-
-    console.log( 'program2::begin' );
-
-  }
-
-}
-
-terminateFirstChildShell.timeOut = 3e5;
-terminateFirstChildShell.description =
-`
 mode : shell
 terminate first child
 first child with signal SIGTERM on unix and exit code 1 on win
 On darwing program1 exists right after signal, program2 continues to work
 On win/linux program1 waits for termination of program2 because only shell was terminated
 `
+
+//
+
+// function terminateFirstChildSpawn( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
+
+//   let o =
+//   {
+//     execPath : 'node program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'spawn',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
+
+//   _.process.start( o ); /* xxx */
+
+//   let program2Pid = null;
+//   let terminate = _.Consequence();
+
+//   o.process.stdout.on( 'data', handleOutput );
+
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : o.process.pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0
+//     })
+//   })
+
+//   o.conTerminate.then( () =>
+//   {
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( o.exitCode, 1 );
+//       test.identical( o.exitSignal, null );
+//     }
+//     else
+//     {
+//       test.identical( o.exitCode, null );
+//       test.identical( o.exitSignal, 'SIGTERM' );
+//     }
+
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+//     test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//     test.is( _.process.isAlive( program2Pid ) );
+
+//     return _.time.out( context.t1*15 );
+//   })
+
+//   o.conTerminate.then( () =>
+//   {
+//     test.is( !_.process.isAlive( program2Pid ) );
+//     test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//     return null;
+//   })
+
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
+
+//   /* - */
+
+//   function handleOutput( output ) /* qqq for Vova : what is it for? aaa:to detect when child process of program1 is ready and we can call terminate*/
+//   {
+//     output = output.toString();
+//     if( !_.strHas( output, 'program2::begin' ) )
+//     return;
+//     o.process.stdout.removeListener( 'data', handleOutput );
+//     terminate.take( null );
+//   }
+
+//   /* - */
+
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+
+//     var o =
+//     {
+//       execPath : 'node program2.js',
+//       currentPath : __dirname,
+//       mode : 'spawn',
+//       stdio : 'pipe',
+//       inputMirroring : 0,
+//       outputPiping : 1,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
+
+//     let timer = _.time.outError( context.t1*25 );
+
+//     console.log( 'program1::begin' );
+//   }
+
+//   /* - */
+
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
+
+//     process.removeAllListeners( 'SIGTERM' )
+
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
+
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//       _.fileProvider.fileWrite( _.path.join( __dirname, 'program2end' ), 'end' );
+//     }, context.t1*10 )
+
+//     console.log( 'program2::begin' );
+
+//   }
+
+// }
+
+// terminateFirstChildSpawn.timeOut = 40000;
+// terminateFirstChildSpawn.description =
+// `
+// mode : spawn
+// terminate first child withChildren:0
+// first child with signal SIGTERM on unix and exit code 1 on win
+// second child continues to work
+// `
+
+//
+
+// function terminateFirstChildFork( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
+
+//   let o =
+//   {
+//     execPath : 'program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'fork',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
+
+//   _.process.start( o );
+
+//   let program2Pid = null;
+//   let terminate = _.Consequence();
+
+//   o.process.stdout.on( 'data', handleOutput );
+
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : o.process.pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0
+//     })
+//   })
+
+//   o.conTerminate.then( () =>
+//   {
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( o.exitCode, 1 );
+//       test.identical( o.exitSignal, null );
+//     }
+//     else
+//     {
+//       test.identical( o.exitCode, null );
+//       test.identical( o.exitSignal, 'SIGTERM' );
+//     }
+
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+//     test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//     test.is( _.process.isAlive( program2Pid ) );
+
+//     return _.time.out( context.t1*15 );
+//   })
+
+//   o.conTerminate.then( () =>
+//   {
+//     test.is( !_.process.isAlive( program2Pid ) );
+//     test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//     return null;
+//   })
+
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
+
+//   /* - */
+
+//   function handleOutput( output )
+//   {
+//     output = output.toString();
+//     if( !_.strHas( output, 'program2::begin' ) )
+//     return;
+//     o.process.stdout.removeListener( 'data', handleOutput );
+//     terminate.take( null );
+//   }
+
+//   /* - */
+
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+
+//     var o =
+//     {
+//       execPath : 'program2.js',
+//       currentPath : __dirname,
+//       mode : 'fork',
+//       stdio : 'pipe',
+//       inputMirroring : 0,
+//       outputPiping : 1,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
+
+//     let timer = _.time.outError( context.t1*25 );
+
+//     console.log( 'program1::begin' );
+//   }
+
+//   /* - */
+
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
+
+//     process.removeAllListeners( 'SIGTERM' )
+
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
+
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//       _.fileProvider.fileWrite( _.path.join( __dirname, 'program2end' ), 'end' );
+//     }, context.t1*10 )
+
+//     console.log( 'program2::begin' );
+
+//   }
+
+// }
+
+// terminateFirstChildFork.timeOut = 40000;
+// terminateFirstChildFork.description =
+// `
+// mode : fork
+// terminate first child
+// first child with signal SIGTERM on unix and exit code 1 on win
+// `
+
+//
+
+// function terminateFirstChildShell( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
+
+//   let o =
+//   {
+//     execPath : 'node program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'shell',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
+
+//   _.process.start( o );
+
+//   let program2Pid = null;
+//   let terminate = _.Consequence();
+
+//   o.process.stdout.on( 'data', handleOutput );
+
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : o.process.pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0
+//     })
+//   })
+
+//   o.conTerminate.then( () =>
+//   {
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( o.exitCode, 1 );
+//       test.identical( o.exitSignal, null );
+//     }
+//     else
+//     {
+//       test.identical( o.exitCode, null );
+//       test.identical( o.exitSignal, 'SIGTERM' );
+//     }
+
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'Time out!' ), 0 );
+
+//     /*
+//        On darwing program1 exists right after signal, program2 continues to work
+//        On win/linux program1 waits for termination of program2 because only shell was terminated
+//     */
+
+//     if( process.platform === 'darwin' )
+//     {
+//       test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+//       test.is( !a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//       test.is( _.process.isAlive( program2Pid ) );
+
+//       return _.time.out( context.t1*15, () =>
+//       {
+//         test.is( !_.process.isAlive( program2Pid ) );
+//         test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//         return null;
+//       });
+//     }
+//     else
+//     {
+//       test.identical( _.strCount( o.output, 'program2::end' ), 1 );
+//       test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//       test.is( !_.process.isAlive( program2Pid ) );
+//     }
+
+//     return null;
+//   })
+
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
+
+//   /* - */
+
+//   function handleOutput( output )
+//   {
+//     output = output.toString();
+//     if( !_.strHas( output, 'program2::begin' ) )
+//     return;
+//     o.process.stdout.removeListener( 'data', handleOutput );
+//     terminate.take( null );
+//   }
+
+//   /* - */
+
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+
+//     var o =
+//     {
+//       execPath : 'node program2.js',
+//       currentPath : __dirname,
+//       mode : 'shell',
+//       stdio : 'pipe',
+//       inputMirroring : 0,
+//       outputPiping : 1,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
+
+//     let timer = _.time.out( context.t1*25 );
+
+//     console.log( 'program1::begin' );
+
+//     process.on( 'exit', () =>
+//     {
+//       console.log( 'program1::end' );
+//     })
+//   }
+
+//   /* - */
+
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
+
+//     process.removeAllListeners( 'SIGTERM' )
+
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
+
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//       _.fileProvider.fileWrite( _.path.join( __dirname, 'program2end' ), 'end' );
+//     }, context.t1*10 )
+
+//     console.log( 'program2::begin' );
+
+//   }
+
+// }
+
+// terminateFirstChildShell.timeOut = 3e5;
+// terminateFirstChildShell.description =
+// `
+// mode : shell
+// terminate first child
+// first child with signal SIGTERM on unix and exit code 1 on win
+// On darwing program1 exists right after signal, program2 continues to work
+// On win/linux program1 waits for termination of program2 because only shell was terminated
+// `
 
 //
 
@@ -33638,9 +33858,10 @@ var Proto =
     terminate, /* qqq for Vova: review, remove duplicates, check timeouts */
     terminateSync,
 
-    terminateFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine | */
-    terminateFirstChildFork,
-    terminateFirstChildShell,
+    terminateFirstChild,
+    // terminateFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine | aaa : Done. */
+    // terminateFirstChildFork,
+    // terminateFirstChildShell,
 
     terminateSecondChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
     terminateSecondChildFork,

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -31422,6 +31422,9 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
       if( a.fileProvider.fileExists( a.abs( 'program1.js' ) ) )
       a.fileProvider.fileDelete( a.abs( 'program1.js' ) );
 
+      if( a.fileProvider.fileExists( a.abs( 'program2Pid.json' ) ) )
+      a.fileProvider.fileDelete( a.abs( 'program2Pid.json' ) );
+
       return null;
     } )
 
@@ -31445,8 +31448,19 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
     
       let program2Pid = null;
       let terminate = _.Consequence();
-    
+      /* For mode::shell */
+      // let timerIsRunning;
+      // let timer;
+
+      // if( mode === 'shell' )
+      // {
+      //   timerIsRunning = { isRunning : true };
+      //   timer = waitForProgram2Ready( terminate, timerIsRunning );
+      // }
+      // else
+      // {
       o.process.stdout.on( 'data', _.routineJoin( null, handleOutput, [ o, terminate ] ) );
+      // }
     
       terminate.then( () =>
       {
@@ -31462,6 +31476,12 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
     
       o.conTerminate.then( () =>
       {
+        // if( mode === 'shell' )
+        // {
+        //   if( timerIsRunning.isRunning )
+        //   timer.cancel();
+        // }
+
         if( process.platform === 'win32' )
         {
           test.identical( o.exitCode, 1 );
@@ -31474,6 +31494,9 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
         }
     
         test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+        if( mode === 'shell' )
+        test.ge( _.strCount( o.output, 'program2::begin' ), 0 );
+        else
         test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
         test.identical( _.strCount( o.output, 'program2::end' ), 0 );
         test.is( _.process.isAlive( program2Pid ) );
@@ -31504,6 +31527,20 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
     o.process.stdout.removeListener( 'data', handleOutput );
     terminate.take( null );
   }
+
+  /* - */
+
+  // function waitForProgram2Ready( terminate, timerIsRunning )
+  // {
+  //   let filePath = a.abs( 'program2Pid' );
+  //   return _.time.periodic( context.t0 * 5, () => /* 500 */
+  //   {
+  //     if( !a.fileProvider.fileExists( filePath ) )
+  //     return true;
+  //     timerIsRunning.isRunning = false;
+  //     terminate.take( true );
+  //   })
+  // }
 
   /* - */
 
@@ -31561,7 +31598,8 @@ function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
   }
 }
 
-terminateDetachedFirstChild.timeOut = 120000;
+terminateDetachedFirstChild.timeOut = 12e4; /* Locally : 38.066s */
+terminateDetachedFirstChild.rapidity = -1;
 terminateDetachedFirstChild.description =
 `
 program1 starts program2 in detached mode

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -29852,7 +29852,7 @@ function terminateFirstChild( test )
         test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
         if( mode === 'shell' )
         test.identical( _.strCount( o.output, 'Time out!' ), 0 );
-        // else
+        else
         test.identical( _.strCount( o.output, 'program2::end' ), 0 );
 
         if( mode === 'shell' )

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -1,4 +1,3 @@
-/* eslint-disable */
 ( function _Execution_test_s( )
 {
 
@@ -32248,9 +32247,9 @@ function terminateDetachedFirstChild( test )
 
       let o =
       {
-        execPath : mode === 'fork' ? 'program1.js' : 'node program1.js',
+        execPath : 'node program1.js',
         currentPath : a.routinePath,
-        mode,
+        mode : 'spawn',
         outputPiping : 1,
         outputCollecting : 1,
         throwingExitCode : 0

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -31571,435 +31571,435 @@ program2 should continue to work
 
 //
 
-function terminateDetachedFirstChildSpawn( test )
-{
-  let context = this;
-  let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
-  let testAppPath2 = a.program( program2 );
+// function terminateDetachedFirstChildSpawn( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
 
-  let o =
-  {
-    execPath : 'node program1.js',
-    currentPath : a.routinePath,
-    mode : 'spawn',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
+//   let o =
+//   {
+//     execPath : 'node program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'spawn',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
 
-  _.process.start( o );
+//   _.process.start( o );
 
-  let program2Pid = null;
-  let terminate = _.Consequence();
+//   let program2Pid = null;
+//   let terminate = _.Consequence();
 
-  o.process.stdout.on( 'data', handleOutput );
+//   o.process.stdout.on( 'data', handleOutput );
 
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : o.process.pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0
-    })
-  })
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : o.process.pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0
+//     })
+//   })
 
-  o.conTerminate.then( () =>
-  {
-    if( process.platform === 'win32' )
-    {
-      test.identical( o.exitCode, 1 );
-      test.identical( o.exitSignal, null );
-    }
-    else
-    {
-      test.identical( o.exitCode, null );
-      test.identical( o.exitSignal, 'SIGTERM' );
-    }
+//   o.conTerminate.then( () =>
+//   {
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( o.exitCode, 1 );
+//       test.identical( o.exitSignal, null );
+//     }
+//     else
+//     {
+//       test.identical( o.exitCode, null );
+//       test.identical( o.exitSignal, 'SIGTERM' );
+//     }
 
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::end' ), 0 );
-    test.is( _.process.isAlive( program2Pid ) );
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+//     test.is( _.process.isAlive( program2Pid ) );
 
-    return _.process.waitForDeath({ pid : program2Pid, timeOut : context.t1*15 });
-  })
+//     return _.process.waitForDeath({ pid : program2Pid, timeOut : context.t1*15 });
+//   })
 
-  o.conTerminate.then( () =>
-  {
-    test.is( !_.process.isAlive( program2Pid ) );
-    test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-    return null;
-  })
+//   o.conTerminate.then( () =>
+//   {
+//     test.is( !_.process.isAlive( program2Pid ) );
+//     test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//     return null;
+//   })
 
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
 
-  /* - */
+//   /* - */
 
-  function handleOutput()
-  {
-    if( !_.strHas( o.output, 'program2::begin' ) )
-    return;
-    o.process.stdout.removeListener( 'data', handleOutput );
-    terminate.take( null );
-  }
+//   function handleOutput()
+//   {
+//     if( !_.strHas( o.output, 'program2::begin' ) )
+//     return;
+//     o.process.stdout.removeListener( 'data', handleOutput );
+//     terminate.take( null );
+//   }
 
-  /* - */
+//   /* - */
 
-  function program1()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wProcess' );
-    _.include( 'wFiles' );
-    var o =
-    {
-      execPath : 'node program2.js',
-      currentPath : __dirname,
-      mode : 'spawn',
-      stdio : 'pipe',
-      detaching : 1,
-      inputMirroring : 0,
-      outputPiping : 1,
-      outputCollecting : 0,
-      throwingExitCode : 0,
-    }
-    _.process.start( o );
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+//     var o =
+//     {
+//       execPath : 'node program2.js',
+//       currentPath : __dirname,
+//       mode : 'spawn',
+//       stdio : 'pipe',
+//       detaching : 1,
+//       inputMirroring : 0,
+//       outputPiping : 1,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
 
-    let timer = _.time.outError( context.t1*25 );
+//     let timer = _.time.outError( context.t1*25 );
 
-    console.log( 'program1::begin' );
+//     console.log( 'program1::begin' );
 
-  }
+//   }
 
-  /* - */
+//   /* - */
 
-  function program2()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wFiles' );
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
 
-    _.fileProvider.fileWrite
-    ({
-      filePath : _.path.join( __dirname, 'program2Pid' ),
-      data : { pid : process.pid },
-      encoding : 'json'
-    })
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
 
-    setTimeout( () =>
-    {
-      console.log( 'program2::end' );
-      _.fileProvider.fileWrite
-      ({
-        filePath : _.path.join( __dirname, 'program2end' ),
-        data : 'end'
-      })
-    }, context.t1*10 )
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//       _.fileProvider.fileWrite
+//       ({
+//         filePath : _.path.join( __dirname, 'program2end' ),
+//         data : 'end'
+//       })
+//     }, context.t1*10 )
 
-    console.log( 'program2::begin' );
+//     console.log( 'program2::begin' );
 
-  }
-}
+//   }
+// }
 
-terminateDetachedFirstChildSpawn.timeOut = 60000;
-terminateDetachedFirstChildSpawn.description =
-`
-program1 starts program2 in detached mode
-tester terminates program1 with option withChildren : 0
-program2 should continue to work
-`
-
-//
-
-function terminateDetachedFirstChildFork( test )
-{
-  let context = this;
-  let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
-  let testAppPath2 = a.program( program2 );
-
-  let o =
-  {
-    execPath : 'program1.js',
-    currentPath : a.routinePath,
-    mode : 'fork',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
-
-  _.process.start( o );
-
-  let program2Pid = null;
-  let terminate = _.Consequence();
-
-  o.process.stdout.on( 'data', handleOutput );
-
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : o.process.pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0
-    })
-  })
-
-  o.conTerminate.then( () =>
-  {
-    if( process.platform === 'win32' )
-    {
-      test.identical( o.exitCode, 1 );
-      test.identical( o.exitSignal, null );
-    }
-    else
-    {
-      test.identical( o.exitCode, null );
-      test.identical( o.exitSignal, 'SIGTERM' );
-    }
-
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
-    test.identical( _.strCount( o.output, 'program2::end' ), 0 );
-    test.is( _.process.isAlive( program2Pid ) );
-
-    return _.process.waitForDeath({ pid : program2Pid, timeOut : context.t1*15 });
-  })
-
-  o.conTerminate.then( () =>
-  {
-    test.is( !_.process.isAlive( program2Pid ) );
-    test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-    return null;
-  })
-
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
-
-  function program1()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wProcess' );
-    _.include( 'wFiles' );
-    var o =
-    {
-      execPath : 'program2.js',
-      currentPath : __dirname,
-      mode : 'fork',
-      stdio : 'pipe',
-      detaching : 1,
-      inputMirroring : 0,
-      outputPiping : 1,
-      outputCollecting : 0,
-      throwingExitCode : 0,
-    }
-    _.process.start( o );
-
-    let timer = _.time.outError( context.t1*25 );
-
-    console.log( 'program1::begin' );
-
-  }
-
-  /* - */
-
-  function handleOutput()
-  {
-    if( !_.strHas( o.output, 'program2::begin' ) )
-    return;
-    o.process.stdout.removeListener( 'data', handleOutput );
-    terminate.take( null );
-  }
-
-  /* - */
-
-  function program2()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wFiles' );
-
-    _.fileProvider.fileWrite
-    ({
-      filePath : _.path.join( __dirname, 'program2Pid' ),
-      data : { pid : process.pid },
-      encoding : 'json'
-    })
-
-    setTimeout( () =>
-    {
-      console.log( 'program2::end' );
-      _.fileProvider.fileWrite
-      ({
-        filePath : _.path.join( __dirname, 'program2end' ),
-        data : 'end'
-      })
-    }, context.t1*10 )
-
-    console.log( 'program2::begin' );
-
-  }
-}
-
-terminateDetachedFirstChildFork.timeOut = 60000;
-terminateDetachedFirstChildFork.description =
-`
-program1 starts program2 in detached mode
-tester terminates program1 with option withChildren : 0
-program2 should continue to work
-`
+// terminateDetachedFirstChildSpawn.timeOut = 60000;
+// terminateDetachedFirstChildSpawn.description =
+// `
+// program1 starts program2 in detached mode
+// tester terminates program1 with option withChildren : 0
+// program2 should continue to work
+// `
 
 //
 
-function terminateDetachedFirstChildShell( test )
-{
-  let context = this;
-  let a = context.assetFor( test, false );
-  let testAppPath = a.program( program1 );
-  let testAppPath2 = a.program( program2 );
+// function terminateDetachedFirstChildFork( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
 
-  let o =
-  {
-    execPath : 'node program1.js',
-    currentPath : a.routinePath,
-    mode : 'spawn',
-    outputPiping : 1,
-    outputCollecting : 1,
-    throwingExitCode : 0
-  }
+//   let o =
+//   {
+//     execPath : 'program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'fork',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
 
-  let terminate = _.Consequence();
-  let timerIsRunning = true;
-  let timer = waitForProgram2Ready();
+//   _.process.start( o );
 
-  _.process.start( o );
+//   let program2Pid = null;
+//   let terminate = _.Consequence();
 
-  let program2Pid = null;
+//   o.process.stdout.on( 'data', handleOutput );
 
-  terminate.then( () =>
-  {
-    program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
-    program2Pid = program2Pid.pid;
-    return _.process.terminate
-    ({
-      pid : o.process.pid,
-      timeOut : context.t1 * 5,
-      withChildren : 0
-    })
-  })
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : o.process.pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0
+//     })
+//   })
 
-  o.conTerminate.then( () =>
-  {
-    if( timerIsRunning )
-    timer.cancel();
+//   o.conTerminate.then( () =>
+//   {
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( o.exitCode, 1 );
+//       test.identical( o.exitSignal, null );
+//     }
+//     else
+//     {
+//       test.identical( o.exitCode, null );
+//       test.identical( o.exitSignal, 'SIGTERM' );
+//     }
 
-    if( process.platform === 'win32' )
-    {
-      test.identical( o.exitCode, 1 );
-      test.identical( o.exitSignal, null );
-    }
-    else
-    {
-      test.identical( o.exitCode, null );
-      test.identical( o.exitSignal, 'SIGTERM' );
-    }
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+//     test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+//     test.is( _.process.isAlive( program2Pid ) );
 
-    test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
-    test.ge( _.strCount( o.output, 'program2::begin' ), 0 );
-    test.identical( _.strCount( o.output, 'program2::end' ), 0 );
-    test.is( _.process.isAlive( program2Pid ) );
+//     return _.process.waitForDeath({ pid : program2Pid, timeOut : context.t1*15 });
+//   })
 
-    return _.process.waitForDeath({ pid : program2Pid, timeOut : context.t1*15 });
-  })
+//   o.conTerminate.then( () =>
+//   {
+//     test.is( !_.process.isAlive( program2Pid ) );
+//     test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//     return null;
+//   })
 
-  o.conTerminate.then( () =>
-  {
-    test.is( !_.process.isAlive( program2Pid ) );
-    test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
-    return null;
-  })
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
 
-  return _.Consequence.AndKeep( terminate, o.conTerminate );
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+//     var o =
+//     {
+//       execPath : 'program2.js',
+//       currentPath : __dirname,
+//       mode : 'fork',
+//       stdio : 'pipe',
+//       detaching : 1,
+//       inputMirroring : 0,
+//       outputPiping : 1,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
 
-  /* - */
+//     let timer = _.time.outError( context.t1*25 );
 
-  function waitForProgram2Ready()
-  {
-    let filePath = a.abs( 'program2Pid' );
-    return _.time.periodic( 500, () =>
-    {
-      if( !a.fileProvider.fileExists( filePath ) )
-      return true;
-      timerIsRunning = false;
-      terminate.take( true );
-    })
-  }
+//     console.log( 'program1::begin' );
 
-  /* - */
+//   }
 
-  function program1()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wProcess' );
-    _.include( 'wFiles' );
-    var o =
-    {
-      execPath : 'node program2.js',
-      currentPath : __dirname,
-      mode : 'shell',
-      stdio : 'pipe',
-      detaching : 1,
-      inputMirroring : 0,
-      outputPiping : 1,
-      outputCollecting : 0,
-      throwingExitCode : 0,
-    }
-    _.process.start( o );
+//   /* - */
 
-    let timer = _.time.outError( context.t1*25 );
+//   function handleOutput()
+//   {
+//     if( !_.strHas( o.output, 'program2::begin' ) )
+//     return;
+//     o.process.stdout.removeListener( 'data', handleOutput );
+//     terminate.take( null );
+//   }
 
-    console.log( 'program1::begin' );
+//   /* - */
 
-  }
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
 
-  /* - */
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
 
-  function program2()
-  {
-    let _ = require( toolsPath );
-    _.include( 'wFiles' );
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//       _.fileProvider.fileWrite
+//       ({
+//         filePath : _.path.join( __dirname, 'program2end' ),
+//         data : 'end'
+//       })
+//     }, context.t1*10 )
 
-    setTimeout( () =>
-    {
-      console.log( 'program2::end' );
-      _.fileProvider.fileWrite
-      ({
-        filePath : _.path.join( __dirname, 'program2end' ),
-        data : 'end'
-      })
-    }, context.t1*10 )
+//     console.log( 'program2::begin' );
 
-    _.fileProvider.fileWrite
-    ({
-      filePath : _.path.join( __dirname, 'program2Pid' ),
-      data : { pid : process.pid },
-      encoding : 'json'
-    })
+//   }
+// }
 
-    console.log( 'program2::begin' );
+// terminateDetachedFirstChildFork.timeOut = 60000;
+// terminateDetachedFirstChildFork.description =
+// `
+// program1 starts program2 in detached mode
+// tester terminates program1 with option withChildren : 0
+// program2 should continue to work
+// `
 
-  }
-}
+//
 
-terminateDetachedFirstChildShell.timeOut = 60000;
-terminateDetachedFirstChildShell.description =
-`
-program1 starts program2 in detached mode
-tester terminates program1 with option withChildren : 0
-program2 should continue to work
-`
+// function terminateDetachedFirstChildShell( test )
+// {
+//   let context = this;
+//   let a = context.assetFor( test, false );
+//   let testAppPath = a.program( program1 );
+//   let testAppPath2 = a.program( program2 );
+
+//   let o =
+//   {
+//     execPath : 'node program1.js',
+//     currentPath : a.routinePath,
+//     mode : 'spawn',
+//     outputPiping : 1,
+//     outputCollecting : 1,
+//     throwingExitCode : 0
+//   }
+
+//   let terminate = _.Consequence();
+//   let timerIsRunning = true;
+//   let timer = waitForProgram2Ready();
+
+//   _.process.start( o );
+
+//   let program2Pid = null;
+
+//   terminate.then( () =>
+//   {
+//     program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+//     program2Pid = program2Pid.pid;
+//     return _.process.terminate
+//     ({
+//       pid : o.process.pid,
+//       timeOut : context.t1 * 5,
+//       withChildren : 0
+//     })
+//   })
+
+//   o.conTerminate.then( () =>
+//   {
+//     if( timerIsRunning )
+//     timer.cancel();
+
+//     if( process.platform === 'win32' )
+//     {
+//       test.identical( o.exitCode, 1 );
+//       test.identical( o.exitSignal, null );
+//     }
+//     else
+//     {
+//       test.identical( o.exitCode, null );
+//       test.identical( o.exitSignal, 'SIGTERM' );
+//     }
+
+//     test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+//     test.ge( _.strCount( o.output, 'program2::begin' ), 0 );
+//     test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+//     test.is( _.process.isAlive( program2Pid ) );
+
+//     return _.process.waitForDeath({ pid : program2Pid, timeOut : context.t1*15 });
+//   })
+
+//   o.conTerminate.then( () =>
+//   {
+//     test.is( !_.process.isAlive( program2Pid ) );
+//     test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+//     return null;
+//   })
+
+//   return _.Consequence.AndKeep( terminate, o.conTerminate );
+
+//   /* - */
+
+//   function waitForProgram2Ready()
+//   {
+//     let filePath = a.abs( 'program2Pid' );
+//     return _.time.periodic( 500, () =>
+//     {
+//       if( !a.fileProvider.fileExists( filePath ) )
+//       return true;
+//       timerIsRunning = false;
+//       terminate.take( true );
+//     })
+//   }
+
+//   /* - */
+
+//   function program1()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wProcess' );
+//     _.include( 'wFiles' );
+//     var o =
+//     {
+//       execPath : 'node program2.js',
+//       currentPath : __dirname,
+//       mode : 'shell',
+//       stdio : 'pipe',
+//       detaching : 1,
+//       inputMirroring : 0,
+//       outputPiping : 1,
+//       outputCollecting : 0,
+//       throwingExitCode : 0,
+//     }
+//     _.process.start( o );
+
+//     let timer = _.time.outError( context.t1*25 );
+
+//     console.log( 'program1::begin' );
+
+//   }
+
+//   /* - */
+
+//   function program2()
+//   {
+//     let _ = require( toolsPath );
+//     _.include( 'wFiles' );
+
+//     setTimeout( () =>
+//     {
+//       console.log( 'program2::end' );
+//       _.fileProvider.fileWrite
+//       ({
+//         filePath : _.path.join( __dirname, 'program2end' ),
+//         data : 'end'
+//       })
+//     }, context.t1*10 )
+
+//     _.fileProvider.fileWrite
+//     ({
+//       filePath : _.path.join( __dirname, 'program2Pid' ),
+//       data : { pid : process.pid },
+//       encoding : 'json'
+//     })
+
+//     console.log( 'program2::begin' );
+
+//   }
+// }
+
+// terminateDetachedFirstChildShell.timeOut = 60000;
+// terminateDetachedFirstChildShell.description =
+// `
+// program1 starts program2 in detached mode
+// tester terminates program1 with option withChildren : 0
+// program2 should continue to work
+// `
 
 //
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -31399,6 +31399,178 @@ second exits with signal SIGTERM on unix and exit code 1 on win
 
 //
 
+function terminateDetachedFirstChild( test ) /* SHELL NOT READY */
+{
+  let context = this;
+  let a = context.assetFor( test, false );
+  let testAppPath2 = a.program( program2 );
+  let modes = [ 'fork', 'spawn', 'shell' ];
+  modes.forEach( ( mode ) => a.ready.then( () => run( mode ) ) );
+  return a.ready;
+
+  /* - */
+
+  function run( mode )
+  {
+    let ready = _.Consequence().take( null );
+
+    ready.then( () =>
+    {
+      if( a.fileProvider.fileExists( a.abs( 'program2end' ) ) )
+      a.fileProvider.fileDelete( a.abs( 'program2end' ) );
+
+      if( a.fileProvider.fileExists( a.abs( 'program1.js' ) ) )
+      a.fileProvider.fileDelete( a.abs( 'program1.js' ) );
+
+      return null;
+    } )
+
+    ready.then( () =>
+    {
+      test.case = `mode : ${mode}`;
+
+      let testAppPath = a.program({ routine : program1, locals : { mode } });
+
+      let o =
+      {
+        execPath : mode === 'fork' ? 'program1.js' : 'node program1.js',
+        currentPath : a.routinePath,
+        mode,
+        outputPiping : 1,
+        outputCollecting : 1,
+        throwingExitCode : 0
+      }
+    
+      _.process.start( o );
+    
+      let program2Pid = null;
+      let terminate = _.Consequence();
+    
+      o.process.stdout.on( 'data', _.routineJoin( null, handleOutput, [ o, terminate ] ) );
+    
+      terminate.then( () =>
+      {
+        program2Pid = _.fileProvider.fileRead({ filePath : a.abs( 'program2Pid' ), encoding : 'json' });
+        program2Pid = program2Pid.pid;
+        return _.process.terminate
+        ({
+          pid : o.process.pid,
+          timeOut : context.t1 * 5,
+          withChildren : 0
+        })
+      })
+    
+      o.conTerminate.then( () =>
+      {
+        if( process.platform === 'win32' )
+        {
+          test.identical( o.exitCode, 1 );
+          test.identical( o.exitSignal, null );
+        }
+        else
+        {
+          test.identical( o.exitCode, null );
+          test.identical( o.exitSignal, 'SIGTERM' );
+        }
+    
+        test.identical( _.strCount( o.output, 'program1::begin' ), 1 );
+        test.identical( _.strCount( o.output, 'program2::begin' ), 1 );
+        test.identical( _.strCount( o.output, 'program2::end' ), 0 );
+        test.is( _.process.isAlive( program2Pid ) );
+    
+        return _.process.waitForDeath({ pid : program2Pid, timeOut : context.t1*15 });
+      })
+    
+      o.conTerminate.then( () =>
+      {
+        test.is( !_.process.isAlive( program2Pid ) );
+        test.is( a.fileProvider.fileExists( a.abs( 'program2end' ) ) );
+        return null;
+      })
+    
+      return _.Consequence.AndKeep( terminate, o.conTerminate );
+    })
+
+    return ready;
+  }
+
+
+  /* - */
+
+  function handleOutput( o, terminate, output )
+  {
+    if( !_.strHas( output.toString(), 'program2::begin' ) )
+    return;
+    o.process.stdout.removeListener( 'data', handleOutput );
+    terminate.take( null );
+  }
+
+  /* - */
+
+  function program1()
+  {
+    let _ = require( toolsPath );
+    _.include( 'wProcess' );
+    _.include( 'wFiles' );
+    var o =
+    {
+      execPath : mode === 'fork' ? 'program2.js' : 'node program2.js',
+      currentPath : __dirname,
+      mode,
+      stdio : 'pipe',
+      detaching : 1,
+      inputMirroring : 0,
+      outputPiping : 1,
+      outputCollecting : 0,
+      throwingExitCode : 0,
+    }
+    _.process.start( o );
+
+    let timer = _.time.outError( context.t1*25 );
+
+    console.log( 'program1::begin' );
+
+  }
+
+  /* - */
+
+  function program2()
+  {
+    let _ = require( toolsPath );
+    _.include( 'wFiles' );
+
+    _.fileProvider.fileWrite
+    ({
+      filePath : _.path.join( __dirname, 'program2Pid' ),
+      data : { pid : process.pid },
+      encoding : 'json'
+    })
+
+    setTimeout( () =>
+    {
+      console.log( 'program2::end' );
+      _.fileProvider.fileWrite
+      ({
+        filePath : _.path.join( __dirname, 'program2end' ),
+        data : 'end'
+      })
+    }, context.t1*10 )
+
+    console.log( 'program2::begin' );
+
+  }
+}
+
+terminateDetachedFirstChild.timeOut = 120000;
+terminateDetachedFirstChild.description =
+`
+program1 starts program2 in detached mode
+tester terminates program1 with option withChildren : 0
+program2 should continue to work
+`
+
+//
+
 function terminateDetachedFirstChildSpawn( test )
 {
   let context = this;
@@ -34829,10 +35001,10 @@ var Proto =
     // terminateSecondChildFork,
     // terminateSecondChildShell,
 
-    // terminateDetachedFirstChild,
-    terminateDetachedFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
-    terminateDetachedFirstChildFork,
-    terminateDetachedFirstChildShell,
+    terminateDetachedFirstChild,
+    // terminateDetachedFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
+    // terminateDetachedFirstChildFork,
+    // terminateDetachedFirstChildShell,
 
     // terminateWithDetachedChild,
     terminateWithDetachedChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */


### PR DESCRIPTION
Locally passes on iOS and Windows. Tests for Ubuntu on github don't run.
   
1.  Write test routine `terminateFirstChild`.
  ```
    terminateFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
    terminateFirstChildFork,
    terminateFirstChildShell,
  ```
2. Write test routine `terminateSecondChild`.
```    
    terminateSecondChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
    terminateSecondChildFork,
    terminateSecondChildShell,
```
3. Write test routine `terminateDetachedFirstChild`.
```
    terminateDetachedFirstChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
    terminateDetachedFirstChildFork,
    terminateDetachedFirstChildShell,
```
4. Write test routine `terminateWithDetachedChild`.
```
    terminateWithDetachedChildSpawn, /* qqq2 for Yevhen : merge those 3 routines into single routine with help of subroutine */
    terminateWithDetachedChildFork,
    terminateWithDetachedChildShell,
```