### PR TITLE
READY : Remove option::outputColoringStderr and option::outputColoringStdout. Extend option::outputColoring

### DIFF
--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -1,4 +1,3 @@
-/* eslint-disable */
 ( function _Execution_test_s( )
 {
 
@@ -18807,7 +18806,7 @@ function startOptionOutputColoringStderr( test )
       {
         test.identical( op.exitCode, 0 );
         test.identical( op.ended, true );
-        let expected = `\u001b[97m > \u001b[39;0m${ mode === 'fork' ? '' : 'node ' }${testAppPath2}\n\u001b[31mError output\u001b[39;0m\n`;
+        let expected = ` > ${ mode === 'fork' ? '' : 'node ' }${testAppPath2}\n\u001b[31mError output\u001b[39;0m\n`;
         test.identical( op.output, expected )
 
         a.fileProvider.fileDelete( testAppPath );
@@ -19084,7 +19083,6 @@ function startOptionOutputColoringStdout( test )
 
     /* */
 
-    /* SPECIAL inputMirroring : 1, outputColoring : { out : 0, err : 1 } => input is colored, but output is not */
     ready.then( () =>
     {
       test.case = `mode : ${ mode }, inputMirroring : 1, outputColoring : { out : 0, err : 1 }, normal output`;
@@ -19111,7 +19109,7 @@ function startOptionOutputColoringStdout( test )
 
         test.identical( op.exitCode, 0 );
         test.identical( op.ended, true );
-        let expected = `\u001b[97m > \u001b[39;0m${ mode === 'fork' ? '' : 'node ' }${testAppPath2}\nLog\n`;
+        let expected = ` > ${ mode === 'fork' ? '' : 'node ' }${testAppPath2}\nLog\n`;
         test.identical( op.output, expected )
 
         a.fileProvider.fileDelete( testAppPath );

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -18673,14 +18673,13 @@ function startOptionOutputColoringStderr( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStderr : 0, inputMirroring : 0, outputColloring : 1`;
+      test.case = `mode : ${ mode }, inputMirroring : 0, outputColloring : { err : 0, out : 1 }, error output`;
 
       let testAppPath2 = a.program( testApp2Error );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStderr : 0,
-        outputColoring : 1,
+        outputColoring : { err : 0, out : 1 },
         inputMirroring : 0,
         outputColoringStdout : null,
         mode,
@@ -18710,51 +18709,13 @@ function startOptionOutputColoringStderr( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStderr : 1, inputMirroring : 0, outputColoring : 0`;
+      test.case = `mode : ${ mode }, inputMirroring : 0, outputColoring : { err : 1, out : 1 }, error output`;
 
       let testAppPath2 = a.program( testApp2Error );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStderr : 1,
-        outputColoring : 0,
-        inputMirroring : 0,
-        outputColoringStdout : null,
-        mode
-      };
-      let testAppPath = a.program({ routine : testApp, locals });
-
-      let options =
-      {
-        execPath : 'node ' + testAppPath,
-        outputCollecting : 1,
-      }
-
-      return _.process.start( options )
-      .then( ( op ) =>
-      {
-        test.identical( op.exitCode, 0 );
-        test.identical( op.ended, true );
-        test.identical( op.output, `Error output\n` )
-
-        a.fileProvider.fileDelete( testAppPath );
-        a.fileProvider.fileDelete( testAppPath2 );
-        return null
-      })
-    } )
-
-    /* */
-
-    ready.then( () =>
-    {
-      test.case = `mode : ${ mode }, outputColoringStderr : 1, inputMirroring : 0, outputColoring : 1`;
-
-      let testAppPath2 = a.program( testApp2Error );
-      let locals =
-      {
-        programPath : testAppPath2,
-        outputColoringStderr : 1,
-        outputColoring : 1,
+        outputColoring : { err : 1, out : 1 },
         inputMirroring : 0,
         outputColoringStdout : null,
         mode
@@ -18784,15 +18745,14 @@ function startOptionOutputColoringStderr( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStderr : 1, inputMirroring : 1, outputColoring : 1`;
+      test.case = `mode : ${ mode }, inputMirroring : 1, outputColoring : { err : 1, out : 1 }, error output`;
 
       let testAppPath2 = a.program( testApp2Error );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStderr : 1,
         inputMirroring : 1,
-        outputColoring : 1,
+        outputColoring : { err : 1, out : 1 },
         outputColoringStdout : null,
         mode
       };
@@ -18822,16 +18782,15 @@ function startOptionOutputColoringStderr( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStderr : 1, outputColoringStdout : 0, inputMirroring : 0, outputColoring : null, normal output`;
+      test.case = `mode : ${ mode }, inputMirroring : 1, outputColoring : { err : 1, out : 0 }, error output`;
 
-      let testAppPath2 = a.program( testApp2 );
+      let testAppPath2 = a.program( testApp2Error );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStderr : 1,
-        outputColoringStdout : 0,
-        inputMirroring : 0,
-        outputColoring : null,
+        inputMirroring : 1,
+        outputColoring : { err : 1, out : 0 },
+        outputColoringStdout : null,
         mode
       };
       let testAppPath = a.program({ routine : testApp, locals });
@@ -18847,7 +18806,8 @@ function startOptionOutputColoringStderr( test )
       {
         test.identical( op.exitCode, 0 );
         test.identical( op.ended, true );
-        test.identical( op.output, 'Log\n' )
+        let expected = `\u001b[97m > \u001b[39;0m${ mode === 'fork' ? '' : 'node ' }${testAppPath2}\n\u001b[31mError output\u001b[39;0m\n`;
+        test.identical( op.output, expected )
 
         a.fileProvider.fileDelete( testAppPath );
         a.fileProvider.fileDelete( testAppPath2 );
@@ -18859,16 +18819,14 @@ function startOptionOutputColoringStderr( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStderr : 1, outputColoringStdout : 0, inputMirroring : 0, outputColoring : 1, normal output`;
+      test.case = `mode : ${ mode }, inputMirroring : 0, outputColoring : { err : 1, out : 0 }, normal output`;
 
       let testAppPath2 = a.program( testApp2 );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStderr : 1,
-        outputColoringStdout : 0,
         inputMirroring : 0,
-        outputColoring : 1,
+        outputColoring : { err : 1, out : 0 },
         mode
       };
       let testAppPath = a.program({ routine : testApp, locals });
@@ -18891,7 +18849,6 @@ function startOptionOutputColoringStderr( test )
         return null
       })
     } )
-
 
     return ready;
 
@@ -18912,8 +18869,6 @@ function startOptionOutputColoringStderr( test )
       outputCollecting : 1,
       mode,
       inputMirroring,
-      outputColoringStderr,
-      outputColoringStdout,
       outputColoring
     }
 
@@ -18952,16 +18907,14 @@ function startOptionOutputColoringStdout( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStdout : 0, inputMirroring : 0, outputColloring : 1`;
+      test.case = `mode : ${ mode }, inputMirroring : 0, outputColloring : { out : 0, err : 1 }, normal output`;
 
       let testAppPath2 = a.program( testApp2 );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStdout : 0,
-        outputColoringStderr : null,
         inputMirroring : 0,
-        outputColoring : 1,
+        outputColoring : { out : 0, err : 1 },
         mode
       };
       let testAppPath = a.program({ routine : testApp, locals });
@@ -18989,54 +18942,14 @@ function startOptionOutputColoringStdout( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStdout : 1, inputMirroring : 0, outputColoring : 0`;
+      test.case = `mode : ${ mode }, inputMirroring : 0, outputColoring : { out : 1, err : 0 }, normal output`;
 
       let testAppPath2 = a.program( testApp2 );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStdout : 1,
-        outputColoringStderr : null,
         inputMirroring : 0,
-        outputColoring : 0,
-        mode
-      };
-      let testAppPath = a.program({ routine : testApp, locals });
-
-      let options =
-      {
-        execPath : 'node ' + testAppPath,
-        outputCollecting : 1,
-      }
-
-      return _.process.start( options )
-      .then( ( op ) =>
-      {
-        debugger;
-        test.identical( op.exitCode, 0 );
-        test.identical( op.ended, true );
-        test.identical( op.output, 'Log\n' )
-
-        a.fileProvider.fileDelete( testAppPath );
-        a.fileProvider.fileDelete( testAppPath2 );
-        return null
-      })
-    } )
-
-    /* */
-
-    ready.then( () =>
-    {
-      test.case = `mode : ${ mode }, outputColoringStdout : 1, inputMirroring : 0, outputColoring : 1`;
-
-      let testAppPath2 = a.program( testApp2 );
-      let locals =
-      {
-        programPath : testAppPath2,
-        outputColoringStdout : 1,
-        outputColoringStderr : null,
-        inputMirroring : 0,
-        outputColoring : 1,
+        outputColoring : { out : 1, err : 0 },
         mode
       };
       let testAppPath = a.program({ routine : testApp, locals });
@@ -19064,16 +18977,49 @@ function startOptionOutputColoringStdout( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStdout : 1, inputMirroring : 1, outputColoring : 1`;
+      test.case = `mode : ${ mode }, inputMirroring : 0, outputColoring : { out : 1, err : 1 }, normal output`;
 
       let testAppPath2 = a.program( testApp2 );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStdout : 1,
-        outputColoringStderr : null,
+        inputMirroring : 0,
+        outputColoring : { out : 1, err : 1 },
+        mode
+      };
+      let testAppPath = a.program({ routine : testApp, locals });
+
+      let options =
+      {
+        execPath : 'node ' + testAppPath,
+        outputCollecting : 1,
+      }
+
+      return _.process.start( options )
+      .then( ( op ) =>
+      {
+        test.identical( op.exitCode, 0 );
+        test.identical( op.ended, true );
+        test.identical( op.output, `\u001b[35mLog\u001b[39;0m\n` )
+
+        a.fileProvider.fileDelete( testAppPath );
+        a.fileProvider.fileDelete( testAppPath2 );
+        return null
+      })
+    } )
+
+    /* */
+
+    ready.then( () =>
+    {
+      test.case = `mode : ${ mode }, inputMirroring : 1, outputColoring : { out : 1, err : 0 }, normal output`;
+
+      let testAppPath2 = a.program( testApp2 );
+      let locals =
+      {
+        programPath : testAppPath2,
         inputMirroring : 1,
-        outputColoring : 1,
+        outputColoring : { out : 1, err : 0 },
         mode
       };
       let testAppPath = a.program({ routine : testApp, locals });
@@ -19103,16 +19049,14 @@ function startOptionOutputColoringStdout( test )
 
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStdout : 1, outputColoringStderr : 0, inputMirroring : 0, outputColoring : null`;
+      test.case = `mode : ${ mode }, inputMirroring : 0, outputColoring : { out : 1, err : 0 }, error output`;
 
       let testAppPath2 = a.program( testApp2Error );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStdout : 1,
-        outputColoringStderr : 0,
         inputMirroring : 0,
-        outputColoring : null,
+        outputColoring : { out : 1, err : 0 },
         mode
       };
       let testAppPath = a.program({ routine : testApp, locals });
@@ -19139,18 +19083,17 @@ function startOptionOutputColoringStdout( test )
 
     /* */
 
+    /* SPECIAL inputMirroring : 1, outputColoring : { out : 0, err : 1 } => input is colored, but output is not */
     ready.then( () =>
     {
-      test.case = `mode : ${ mode }, outputColoringStdout : 1, outputColoringStderr : 0, inputMirroring : 0, outputColoring : 1`;
+      test.case = `mode : ${ mode }, inputMirroring : 1, outputColoring : { out : 0, err : 1 }, normal output`;
 
-      let testAppPath2 = a.program( testApp2Error );
+      let testAppPath2 = a.program( testApp2 );
       let locals =
       {
         programPath : testAppPath2,
-        outputColoringStdout : 1,
-        outputColoringStderr : 0,
-        inputMirroring : 0,
-        outputColoring : 1,
+        inputMirroring : 1,
+        outputColoring : { out : 0, err : 1 },
         mode
       };
       let testAppPath = a.program({ routine : testApp, locals });
@@ -19167,16 +19110,14 @@ function startOptionOutputColoringStdout( test )
 
         test.identical( op.exitCode, 0 );
         test.identical( op.ended, true );
-        test.identical( op.output, 'Error output\n' )
+        let expected = `\u001b[97m > \u001b[39;0m${ mode === 'fork' ? '' : 'node ' }${testAppPath2}\nLog\n`;
+        test.identical( op.output, expected )
 
         a.fileProvider.fileDelete( testAppPath );
         a.fileProvider.fileDelete( testAppPath2 );
         return null
       })
     } )
-
-
-    /* */
 
     return ready;
 
@@ -19197,8 +19138,6 @@ function startOptionOutputColoringStdout( test )
       outputCollecting : 1,
       mode,
       inputMirroring,
-      outputColoringStdout,
-      outputColoringStderr,
       outputColoring
     }
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -18652,6 +18652,8 @@ function startOptionOutputColoring( test )
   }
 }
 
+startOptionOutputColoring.timeOut = 20e4; /* Locally : 19.079s */
+
 //
 
 function startOptionOutputColoringStderr( test )
@@ -18885,6 +18887,8 @@ function startOptionOutputColoringStderr( test )
     console.log( 'Log' );
   }
 }
+
+startOptionOutputColoringStderr.timeOut = 17e4; /* Locally : 16.099s */
 
 //
 
@@ -19154,6 +19158,8 @@ function startOptionOutputColoringStdout( test )
   }
 
 }
+
+startOptionOutputColoringStdout.timeOut = 19e4; /* Locally : 18.513s */
 
 //
 

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -1,3 +1,4 @@
+/* eslint-disable */
 ( function _Execution_test_s( )
 {
 

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -1895,7 +1895,7 @@ function startMultiple_body( o )
     // _.assert( _.boolLike( o.outputColoring ) );
     // _.assert( _.boolLike( o.outputColoringStdout ) );
     // _.assert( _.boolLike( o.outputColoringStderr ) );
-    _.assert( _.boolLike( o.outputColoring ) || _.objectIs( o.outputColoring ) );
+    _.assert( _.objectIs( o.outputColoring ) );
     _.assert( _.boolLike( o.outputCollecting ) );
 
     if( o.outputAdditive === null )

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -1405,7 +1405,7 @@ startMinimal_body.defaults =
   outputGraying : 0,
   inputMirroring : 1, /* qqq for Yevhen : cover the option | aaa : Done */
 
-  /* qqq for Yevhen : remove option::outputColoringStderr and option::outputColoringStdout. extend outputColoring */
+  /* qqq for Yevhen : remove option::outputColoringStderr and option::outputColoringStdout. extend outputColoring. */
 
 }
 

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -98,12 +98,12 @@ function startMinimalHeadCommon( routine, args )
   _.assert
   (
     _.boolLike( o.outputColoring.out ),
-    `o.outputColoring.out supports values::[ 1, 0, true, false ], but got ${o.outputColoring.out}`
+    `o.outputColoring.out expects BoolLike, but got ${o.outputColoring.out}`
   );
   _.assert
   (
     _.boolLike( o.outputColoring.err ),
-    `o.outputColoring.err supports values::[ 1, 0, true, false ], but got ${o.outputColoring.err}`
+    `o.outputColoring.err expects BoolLike, but got ${o.outputColoring.err}`
   );
 
   if( !_.numberIs( o.verbosity ) )
@@ -1421,7 +1421,7 @@ startMinimal_body.defaults =
   outputPiping : null,
   outputCollecting : 0,
   outputAdditive : null, /* qqq for Yevhen : cover the option */
-  outputColoring : 1, /* qqq for Yevhen : cover the option */
+  outputColoring : 1, /* qqq for Yevhen : cover the option | aaa : Done. */
   // outputColoringStderr : null, /* qqq for Yevhen : cover the option */
   // outputColoringStdout : null, /* qqq for Yevhen : cover the option */
   outputGraying : 0,

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -98,12 +98,12 @@ function startMinimalHeadCommon( routine, args )
   _.assert
   (
     _.boolLike( o.outputColoring.out ),
-    `o.outputColoring.out supports values:[ 1, 0, true, false ], but got ${o.outputColoring.out}`
+    `o.outputColoring.out supports values::[ 1, 0, true, false ], but got ${o.outputColoring.out}`
   );
   _.assert
   (
     _.boolLike( o.outputColoring.err ),
-    `o.outputColoring.err supports values:[ 1, 0, true, false ], but got ${o.outputColoring.err}`
+    `o.outputColoring.err supports values::[ 1, 0, true, false ], but got ${o.outputColoring.err}`
   );
 
   if( !_.numberIs( o.verbosity ) )

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -1067,7 +1067,7 @@ function startMinimal_body( o )
       {
         let output = ' @ ';
         // if( o.outputColoring ) /* ??? */
-        if( o.outputColoring.out || o.outputColoring.err )
+        if( o.outputColoring.out )
         output = _.ct.format( output, { fg : 'bright white' } ) + _.ct.format( o.currentPath, 'path' );
         else
         output = output + o.currentPath
@@ -1078,7 +1078,7 @@ function startMinimal_body( o )
       {
         let prefix = ' > ';
         // if( o.outputColoring ) /* ??? */
-        if( o.outputColoring.out || o.outputColoring.err )
+        if( o.outputColoring.out )
         prefix = _.ct.format( prefix, { fg : 'bright white' } );
         log( prefix + o.fullExecPath, 'out' );
       }

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -1455,7 +1455,7 @@ startMinimal_body.defaults =
   outputGraying : 0,
   inputMirroring : 1, /* qqq for Yevhen : cover the option | aaa : Done */
 
-  /* qqq for Yevhen : remove option::outputColoringStderr and option::outputColoringStdout. extend outputColoring. */
+  /* qqq for Yevhen : remove option::outputColoringStderr and option::outputColoringStdout. extend outputColoring | aaa : Done.  */
 
 }
 

--- a/proto/wtools/abase/l4_process/l3/Execution.s
+++ b/proto/wtools/abase/l4_process/l3/Execution.s
@@ -1066,7 +1066,6 @@ function startMinimal_body( o )
       if( o.verbosity >= 3 )
       {
         let output = ' @ ';
-        // if( o.outputColoring ) /* ??? */
         if( o.outputColoring.out )
         output = _.ct.format( output, { fg : 'bright white' } ) + _.ct.format( o.currentPath, 'path' );
         else
@@ -1077,7 +1076,6 @@ function startMinimal_body( o )
       if( o.verbosity )
       {
         let prefix = ' > ';
-        // if( o.outputColoring ) /* ??? */
         if( o.outputColoring.out )
         prefix = _.ct.format( prefix, { fg : 'bright white' } );
         log( prefix + o.fullExecPath, 'out' );


### PR DESCRIPTION
1. Locally passes on iOS and Windows. Tests for Ubuntu on github don't run.
/* qqq for Yevhen : remove option::outputColoringStderr and option::outputColoringStdout. extend outputColoring. */