### PR TITLE
NOT READY : Fixed test routines for windows .

### DIFF
--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -10288,10 +10288,18 @@ function startMinimalOptionTimeOut( test )
       return test.shouldThrowErrorAsync( o.conTerminate )
       .then( () =>
       {
-        /* Child process on Windows terminates with 'SIGTERM' because process was terminated using process descriptor*/
-        test.identical( o.exitCode, null );
         test.identical( o.ended, true );
-        test.identical( o.exitSignal, 'SIGTERM' );
+        /* Child process on Windows terminates with 'SIGTERM' because process was terminated using process descriptor */
+        if( process.platform === 'win32' )
+        {
+          test.identical( o.exitCode, 1 );
+          test.identical( o.exitSignal, null );
+        }
+        else
+        {
+          test.identical( o.exitCode, null );
+          test.identical( o.exitSignal, 'SIGTERM' );
+        }
 
         return null;
       })
@@ -10318,9 +10326,9 @@ function startMinimalOptionTimeOut( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( o.exitCode, null );
+          test.identical( o.exitCode, 1 );
           test.identical( o.ended, true );
-          test.identical( o.exitSignal, 'SIGTERM' );
+          test.identical( o.exitSignal, null );
         }
         else if( process.platform === 'darwin' )
         {
@@ -10365,9 +10373,9 @@ function startMinimalOptionTimeOut( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( o.exitCode, null );
+          test.identical( o.exitCode, 1 );
           test.identical( o.ended, true );
-          test.identical( o.exitSignal, 'SIGTERM' );
+          test.identical( o.exitSignal, null );
           test.true( !_.strHas( o.output, 'Process was killed by exit signal SIGTERM' ) );
         }
         else
@@ -10405,9 +10413,9 @@ function startMinimalOptionTimeOut( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( o.exitCode, null );
+          test.identical( o.exitCode, 1 );
           test.identical( o.ended, true );
-          test.identical( o.exitSignal, 'SIGTERM' );
+          test.identical( o.exitSignal, null );
         }
         else if( process.platform === 'darwin' )
         {

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -33546,24 +33546,24 @@ function terminateSync( test )
 
       o.conTerminate.then( ( op ) =>
       {
-        if( mode === 'shell' )
+        if( process.platform === 'win32' )
         {
-          test.identical( op.exitCode, null );
           test.identical( op.ended, true );
-          test.identical( op.exitSignal, 'SIGKILL' );
+          test.identical( op.exitCode, 1 );
+          test.identical( op.exitSignal, null );
           test.true( !_.strHas( op.output, 'SIGTERM' ) );
           test.true( !_.strHas( op.output, 'Application timeout!' ) );
-          return null;
         }
         else
         {
-          if( process.platform === 'win32' )
+          if( mode === 'shell' )
           {
-            test.identical( op.ended, true );
             test.identical( op.exitCode, null );
-            test.identical( op.exitSignal, 'SIGTERM' );
+            test.identical( op.ended, true );
+            test.identical( op.exitSignal, 'SIGKILL' );
             test.true( !_.strHas( op.output, 'SIGTERM' ) );
             test.true( !_.strHas( op.output, 'Application timeout!' ) );
+            return null;
           }
           else
           {
@@ -33572,8 +33572,8 @@ function terminateSync( test )
             test.identical( op.exitSignal, 'SIGTERM' );
             test.true( !_.strHas( op.output, 'Application timeout!' ) );
           }
-          return null;
         }
+        return null;
       })
 
       return _.time.out( context.t1*4, () =>

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -28558,9 +28558,18 @@ function kill( test )
 
       returned.then( ( op ) =>
       {
-        test.identical( op.exitCode, null );
-        test.identical( op.ended, true );
-        test.identical( op.exitSignal, 'SIGKILL' );
+        if( process.platform === 'win32' )
+        {
+          test.identical( op.exitCode, 1 );
+          test.identical( op.ended, true );
+          test.identical( op.exitSignal, null );
+        }
+        else
+        {
+          test.identical( op.exitCode, null );
+          test.identical( op.ended, true );
+          test.identical( op.exitSignal, 'SIGKILL' );
+        }
         test.true( !_.strHas( op.output, 'Application timeout!' ) );
         return null;
       })

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -30223,12 +30223,17 @@ function startMinimalTerminateAfterLoopRelease( test )
 
       con.then( () =>
       {
-        test.identical( o.exitCode, null );
         /* njs on Windows does not let to set custom signal handler properly */
         if( process.platform === 'win32' )
-        test.identical( o.exitSignal, 'SIGTERM' );
+        {
+          test.identical( o.exitCode, 1 );
+          test.identical( o.exitSignal, null );
+        }
         else
-        test.identical( o.exitSignal, 'SIGKILL' );
+        {
+          test.identical( o.exitCode, null );
+          test.identical( o.exitSignal, 'SIGKILL' );
+        }
         test.true( !_.strHas( o.output, 'SIGTERM' ) );
         test.true( !_.strHas( o.output, 'Exit after release' ) );
 
@@ -32384,11 +32389,22 @@ exit:end
         test.identical( options.error, null );
         test.identical( options.pnd.killed, false );
 
-        test.identical( options.exitCode, null );
-        test.identical( options.exitSignal, 'SIGTERM' );
-        test.identical( options.exitReason, 'signal' );
-        test.identical( options.pnd.signalCode, 'SIGTERM' );
-        test.identical( options.pnd.exitCode, null );
+        if( process.platform === 'win32' )
+        {
+          test.identical( options.exitCode, 1 );
+          test.identical( options.exitSignal, null );
+          test.identical( options.exitReason, 'code' );
+          test.identical( options.pnd.signalCode, null );
+          test.identical( options.pnd.exitCode, 1 );
+        }
+        else
+        {
+          test.identical( options.exitCode, null );
+          test.identical( options.exitSignal, 'SIGTERM' );
+          test.identical( options.exitReason, 'signal' );
+          test.identical( options.pnd.signalCode, 'SIGTERM' );
+          test.identical( options.pnd.exitCode, null );
+        }
 
         var dtime = _.time.now() - time1;
         console.log( `dtime:${dtime}` );
@@ -32912,8 +32928,8 @@ function terminate( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( op.exitCode, null );
-          test.identical( op.exitSignal, 'SIGTERM' );
+          test.identical( op.exitCode, 1 );
+          test.identical( op.exitSignal, null );
           test.identical( op.ended, true );
           test.true( !_.strHas( op.output, 'SIGTERM' ) );
           test.true( !_.strHas( op.output, 'Application timeout!' ) );
@@ -33114,9 +33130,9 @@ function terminate( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( op.exitCode, null );
+          test.identical( op.exitCode, 1 );
           test.identical( op.ended, true );
-          test.identical( op.exitSignal, 'SIGKILL' );
+          test.identical( op.exitSignal, null );
           test.true( !_.strHas( op.output, 'SIGTERM' ) );
           test.true( !_.strHas( op.output, 'Application timeout!' ) );
         }
@@ -33161,8 +33177,8 @@ function terminate( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( op.exitCode, null );
-          test.identical( op.exitSignal, 'SIGTERM' );
+          test.identical( op.exitCode, 1 );
+          test.identical( op.exitSignal, null );
           test.identical( op.ended, true );
           test.true( !_.strHas( op.output, 'SIGTERM' ) );
           test.true( !_.strHas( op.output, 'Application timeout!' ) );
@@ -33216,9 +33232,9 @@ function terminate( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( op.exitCode, null );/* null because process was killed using pnd */
+          test.identical( op.exitCode, 1 );/* null because process was killed using pnd */
           test.identical( op.ended, true );
-          test.identical( op.exitSignal, 'SIGTERM' );
+          test.identical( op.exitSignal, null );
           test.true( !_.strHas( op.output, 'SIGTERM' ) );
           test.true( !_.strHas( op.output, 'Application timeout!' ) );
         }
@@ -33308,9 +33324,9 @@ function terminate( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( op.exitCode, null );/* null because process was killed using pnd */
+          test.identical( op.exitCode, 1 );/* null because process was killed using pnd */
           test.identical( op.ended, true );
-          test.identical( op.exitSignal, 'SIGKILL' );
+          test.identical( op.exitSignal, null );
           test.true( !_.strHas( op.output, 'SIGTERM' ) );
           test.true( !_.strHas( op.output, 'Application timeout!' ) );
         }
@@ -33397,9 +33413,9 @@ function terminate( test )
       {
         if( process.platform === 'win32' )
         {
-          test.identical( op.exitCode, null );
+          test.identical( op.exitCode, 1 );
           test.identical( op.ended, true );
-          test.identical( op.exitSignal, 'SIGTERM' );
+          test.identical( op.exitSignal, null );
           test.true( !_.strHas( op.output, 'SIGTERM' ) );
           test.true( !_.strHas( op.output, 'Application timeout!' ) );
         }

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -32533,11 +32533,22 @@ Killed
         test.identical( options.error, null );
         test.identical( options.pnd.killed, false );
 
-        test.identical( options.exitCode, null );
-        test.identical( options.exitSignal, 'SIGKILL' );
-        test.identical( options.exitReason, 'signal' );
-        test.identical( options.pnd.signalCode, 'SIGKILL' );
-        test.identical( options.pnd.exitCode, null );
+        if( process.platfrom === 'win32' )
+        {
+          test.identical( options.exitCode, 1 );
+          test.identical( options.exitSignal, null );
+          test.identical( options.exitReason, 'code' );
+          test.identical( options.pnd.signalCode, null );
+          test.identical( options.pnd.exitCode, 1 );
+        }
+        else
+        {
+          test.identical( options.exitCode, null );
+          test.identical( options.exitSignal, 'SIGKILL' );
+          test.identical( options.exitReason, 'signal' );
+          test.identical( options.pnd.signalCode, 'SIGKILL' );
+          test.identical( options.pnd.exitCode, null );
+        }
 
         var dtime = _.time.now() - time1;
         console.log( `dtime:${dtime}` );

--- a/proto/wtools/abase/l4_process.test/Execution.test.s
+++ b/proto/wtools/abase/l4_process.test/Execution.test.s
@@ -29011,9 +29011,19 @@ function killSync( test )
       ready1.then( ( op ) =>
       {
         /* Same result on Windows because process was killed using pnd, not pid */
-        test.identical( op.exitCode, null );
-        test.identical( op.exitSignal, 'SIGKILL' );
-        test.identical( op.ended, true );
+        if( process.platform === 'win32' )
+        {
+          test.identical( op.exitCode, 1 );
+          test.identical( op.exitSignal, null );
+          test.identical( op.ended, true );
+        }
+        else
+        {
+          test.identical( op.exitCode, null );
+          test.identical( op.exitSignal, 'SIGKILL' );
+          test.identical( op.ended, true );
+        }
+        
         test.true( !_.strHas( op.output, 'Application timeout!' ) );
         return null;
       })


### PR DESCRIPTION
1. `startMinimalOptionTimeOut`.
2. `kill`.
3. `killSync`
4. `startMinimalTerminateAfterLoopRelease`.
5. `endSignalsOnExit`.
6.  `terminate`.
7.  `terminateSync`